### PR TITLE
Remove package-lock from ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ __pycache__/
 
 ## Node
 node_modules
-package-lock.json
 /src/doc/rustc-dev-guide/mermaid.min.js
 
 ## Rustdoc GUI tests


### PR DESCRIPTION
## Summary
- allow `package-lock.json` to be tracked by git by removing it from `.gitignore`

## Testing
- `npm test` *(fails: vitest not found)*