### PR TITLE
Stub wasm integration and pointer drag behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build:wasm": "echo \"stub wasm build\"",
+        "build:wasm": "wasm-pack build rust --target web --out-dir src/wasm-bindings",
         "build": "npm run build:wasm && vite build",
         "lint": "eslint --ext .ts src",
         "test": "vitest"

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -1,12 +1,50 @@
+import { process_drag } from '../../wasm-bindings/cc_web_components.js';
+
 export class DraggableNumber extends HTMLElement {
     static get observedAttributes() {
         return ['value'];
     }
 
+    private _dragging = false;
+    private _startValue = 0;
+    private _startX = 0;
+
     constructor() {
         super();
         const shadow = this.attachShadow({ mode: 'open' });
         shadow.innerHTML = `<input type="number" />`;
+    }
+
+    connectedCallback() {
+        const input = this.shadowRoot?.querySelector('input') as HTMLInputElement | null;
+        if (!input) return;
+
+        input.addEventListener('change', () => {
+            this.setAttribute('value', input.value);
+            this.dispatchEvent(new Event('change'));
+        });
+
+        input.addEventListener('pointerdown', (e: PointerEvent) => {
+            this._dragging = true;
+            this._startX = e.clientX;
+            this._startValue = parseFloat(this.getAttribute('value') ?? '0');
+            input.setPointerCapture(e.pointerId);
+        });
+
+        input.addEventListener('pointermove', (e: PointerEvent) => {
+            if (!this._dragging) return;
+            const delta = e.clientX - this._startX;
+            const newVal = this._startValue + process_drag(delta);
+            this.setAttribute('value', String(newVal));
+            this.dispatchEvent(new Event('change'));
+        });
+
+        const stopDrag = () => {
+            this._dragging = false;
+        };
+
+        input.addEventListener('pointerup', stopDrag);
+        input.addEventListener('pointercancel', stopDrag);
     }
 
     attributeChangedCallback(name: string, _oldVal: string | null, newVal: string | null) {

--- a/src/wasm-bindings/cc_web_components.js
+++ b/src/wasm-bindings/cc_web_components.js
@@ -1,0 +1,13 @@
+export async function init() {
+    // This stub mimics the wasm-bindgen generated init function
+    // In a real build, this would fetch and instantiate the WebAssembly module.
+    return {
+        process_drag
+    };
+}
+
+export function process_drag(delta) {
+    // Stub implementation that just returns the delta.
+    // Actual logic will live in Rust and be compiled to WASM.
+    return delta;
+}


### PR DESCRIPTION
## Summary
- stub generated wasm module with `process_drag`
- handle pointer dragging in `<cc-draggable-number>` and call `process_drag`
- wire up wasm build script via `wasm-pack`

## Testing
- `npm test` *(fails: `vitest` not found)*
- `cargo test` *(fails: could not connect to server)*