### PR TITLE
Align workflow triggers and Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
 jobs:
   build-test:
     runs-on: ubuntu-latest
@@ -12,7 +11,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
@@ -43,8 +42,6 @@ jobs:
         run: npm run test -- --coverage || true
       - name: Build Library (Vite)
         run: npm run build
-      - name: Run Lint
-        run: npm run lint || true
       - name: Upload Coverage Report
         if: success() && exists('coverage')
         uses: actions/upload-artifact@v3

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,8 +1,9 @@
 name: ESLint
 
 on:
-  pull_request:
+  push:
     branches: [ master ]
+  pull_request:
 
 jobs:
   lint:
@@ -11,6 +12,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: 22
       - run: npm install
       - run: npm run lint


### PR DESCRIPTION
## Summary
- run eslint workflow on PRs and master push
- run CI workflow on PRs and master push
- drop linting from CI job
- use Node 22 in both workflows

## Testing
- `npm test` *(fails: `ReferenceError: HTMLElement is not defined`)*
- `cargo test` *(fails: could not download `wasm-bindgen`)*
