### PR TITLE
Fix CI coverage condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build Library (Vite)
         run: npm run build
       - name: Upload Coverage Report
-        if: success() && exists('coverage')
+        if: ${{ success() && hashFiles('coverage/**') != '' }}
         uses: actions/upload-artifact@v3
         with:
           name: coverage-report


### PR DESCRIPTION
## Summary
- update coverage upload check in CI

## Testing
- `npm run lint`
- `npx vitest run` *(fails: `ReferenceError: HTMLElement is not defined`)*