### PR TITLE
Add property-input component

### DIFF
--- a/src/components/property-input/index.ts
+++ b/src/components/property-input/index.ts
@@ -1,0 +1,79 @@
+import { LitElement, css, unsafeCSS } from 'lit';
+import componentStyles from './style.css?inline';
+import { template } from './template';
+
+type DraggableNumberElement = HTMLElement & { value: number };
+
+export class PropertyInput extends LitElement {
+    static styles = css`${unsafeCSS(componentStyles)}`;
+
+    static properties = {
+        value: { type: Number, reflect: true }
+    };
+
+    value = 0;
+
+    private _listeners = new Map<DraggableNumberElement, EventListener>();
+
+    render() {
+        return template(this._onSlotChange.bind(this));
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._setupListeners();
+    }
+
+    updated(changed: Map<string, unknown>) {
+        if (changed.has('value')) {
+            this._updateChildren();
+            if (changed.get('value') !== undefined) {
+                this.dispatchEvent(new Event('change'));
+            }
+        }
+    }
+
+    private _onSlotChange() {
+        this._setupListeners();
+    }
+
+    private _setupListeners() {
+        const numbers = this.querySelectorAll<DraggableNumberElement>('cc-draggable-number');
+        numbers.forEach((num) => {
+            if (this._listeners.has(num)) return;
+            const handler = this._onChildChange.bind(this);
+            num.addEventListener('change', handler as EventListener);
+            this._listeners.set(num, handler);
+            num.value = this.value;
+        });
+        this._listeners.forEach((handler, num) => {
+            if (!num.isConnected || !this.contains(num)) {
+                num.removeEventListener('change', handler as EventListener);
+                this._listeners.delete(num);
+            }
+        });
+    }
+
+    private _onChildChange(e: Event) {
+        const target = e.target as DraggableNumberElement;
+        const newVal = typeof target.value === 'number' ? target.value : parseFloat(target.getAttribute('value') ?? '');
+        if (!isNaN(newVal) && newVal !== this.value) {
+            this.value = newVal;
+        }
+    }
+
+    private _updateChildren() {
+        const numbers = this.querySelectorAll<DraggableNumberElement>('cc-draggable-number');
+        numbers.forEach((num) => {
+            if (num.value !== this.value) {
+                num.value = this.value;
+            }
+        });
+    }
+}
+
+export function definePropertyInput() {
+    if (!customElements.get('cc-property-input')) {
+        customElements.define('cc-property-input', PropertyInput);
+    }
+}

--- a/src/components/property-input/style.css
+++ b/src/components/property-input/style.css
@@ -1,0 +1,3 @@
+:host {
+    display: inline-block;
+}

--- a/src/components/property-input/template.ts
+++ b/src/components/property-input/template.ts
@@ -1,0 +1,3 @@
+import { html } from 'lit';
+
+export const template = (onSlotChange: () => void) => html`<slot @slotchange=${onSlotChange}></slot>`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import { defineDraggableNumber } from './components/draggable-number';
+import { definePropertyInput } from './components/property-input';
 
 defineDraggableNumber();
+definePropertyInput();
 
 export * from './components/draggable-number';
+export * from './components/property-input';

--- a/tests/property-input.test.ts
+++ b/tests/property-input.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { defineDraggableNumber } from '../src/components/draggable-number';
+import { definePropertyInput } from '../src/components/property-input';
+
+defineDraggableNumber();
+definePropertyInput();
+
+const hasDom = typeof document !== 'undefined';
+(hasDom ? describe : describe.skip)('property-input', () => {
+    it('syncs value between nested draggable numbers', () => {
+        document.body.innerHTML = `
+            <cc-property-input value="5">
+                <cc-draggable-number></cc-draggable-number>
+                <cc-draggable-number></cc-draggable-number>
+            </cc-property-input>
+        `;
+
+        const container = document.querySelector('cc-property-input') as any;
+        const [first, second] = Array.from(
+            container.querySelectorAll('cc-draggable-number')
+        ) as any[];
+
+        expect(first.value).toBe(5);
+        expect(second.value).toBe(5);
+
+        let changeCount = 0;
+        container.addEventListener('change', () => changeCount++);
+
+        first.value = 12;
+        first.dispatchEvent(new Event('change'));
+
+        expect(container.value).toBe(12);
+        expect(second.value).toBe(12);
+        expect(changeCount).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary
- create `cc-property-input` component that synchronizes value with nested draggable numbers
- export the component from the main entry file
- add a basic (skipped without DOM) test demonstrating usage

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm run test`