### PR TITLE
Add rotation property input component

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,16 @@ Run `npm run test` to execute the test suite.
 Linting is performed on both TypeScript and Rust code using ESLint, rustfmt and
 clippy. Install the Rust components with `rustup component add rustfmt clippy`.
 Run `npm run lint` to check formatting and common issues.
+
+## Rotation Property Input
+
+`<cc-rotation-property-input>` displays an angle as full rotations and partial degrees.
+The value is shown in the format `Nx±D°`, where `N` is the number of full `360°` rotations
+and `D` is the remaining degrees. Internally it uses `cc-property-input` with two nested
+`cc-draggable-number` elements.
+
+```html
+<cc-rotation-property-input value="390"></cc-rotation-property-input>
+```
+
+The example above renders the value as `1x+30°`.

--- a/src/components/rotation-property-input/index.ts
+++ b/src/components/rotation-property-input/index.ts
@@ -1,0 +1,64 @@
+import { LitElement, css, unsafeCSS } from 'lit';
+import componentStyles from './style.css?inline';
+import { template } from './template';
+import { defineDraggableNumber } from '../draggable-number';
+import { definePropertyInput } from '../property-input';
+
+type DraggableNumberElement = HTMLElement & { value: number };
+
+export class RotationPropertyInput extends LitElement {
+    static styles = css`${unsafeCSS(componentStyles)}`;
+
+    static properties = {
+        value: { type: Number, reflect: true }
+    };
+
+    value = 0;
+
+    private _split(value: number) {
+        const rotations = Math.trunc(value / 360);
+        const remainder = value - rotations * 360;
+        const sign = remainder >= 0 ? '+' : '-';
+        const degrees = Math.abs(remainder);
+        return { rotations, sign, degrees };
+    }
+
+    private _onRotationsChange(e: Event) {
+        const rot = (e.target as DraggableNumberElement).value;
+        const { sign, degrees } = this._split(this.value);
+        const signedDeg = sign === '-' ? -degrees : degrees;
+        this.value = rot * 360 + signedDeg;
+        this.dispatchEvent(new Event('change'));
+    }
+
+    private _onDegreesChange(e: Event) {
+        const deg = (e.target as DraggableNumberElement).value;
+        const { rotations, sign } = this._split(this.value);
+        const signedDeg = sign === '-' ? -deg : deg;
+        this.value = rotations * 360 + signedDeg;
+        this.dispatchEvent(new Event('change'));
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        definePropertyInput();
+        defineDraggableNumber();
+    }
+
+    render() {
+        const { rotations, sign, degrees } = this._split(this.value);
+        return template(
+            rotations,
+            sign,
+            degrees,
+            this._onRotationsChange.bind(this),
+            this._onDegreesChange.bind(this)
+        );
+    }
+}
+
+export function defineRotationPropertyInput() {
+    if (!customElements.get('cc-rotation-property-input')) {
+        customElements.define('cc-rotation-property-input', RotationPropertyInput);
+    }
+}

--- a/src/components/rotation-property-input/style.css
+++ b/src/components/rotation-property-input/style.css
@@ -1,0 +1,3 @@
+:host {
+    display: inline-block;
+}

--- a/src/components/rotation-property-input/template.ts
+++ b/src/components/rotation-property-input/template.ts
@@ -1,0 +1,22 @@
+import { html } from 'lit';
+
+export const template = (
+    rotations: number,
+    sign: string,
+    degrees: number,
+    onRotationsChange: (e: Event) => void,
+    onDegreesChange: (e: Event) => void
+) => html`<cc-property-input>
+    <cc-draggable-number
+        part="rotations"
+        .value=${rotations}
+        @change=${onRotationsChange}
+    ></cc-draggable-number>
+    <span>x${sign}</span>
+    <cc-draggable-number
+        part="degrees"
+        .value=${degrees}
+        @change=${onDegreesChange}
+    ></cc-draggable-number>
+    <span>°</span>
+</cc-property-input>`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 import { defineDraggableNumber } from './components/draggable-number';
 import { definePropertyInput } from './components/property-input';
+import { defineRotationPropertyInput } from './components/rotation-property-input';
 
 defineDraggableNumber();
 definePropertyInput();
+defineRotationPropertyInput();
 
 export * from './components/draggable-number';
 export * from './components/property-input';
+export * from './components/rotation-property-input';

--- a/tests/rotation-property-input.test.ts
+++ b/tests/rotation-property-input.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { defineDraggableNumber } from '../src/components/draggable-number';
+import { definePropertyInput } from '../src/components/property-input';
+import { defineRotationPropertyInput } from '../src/components/rotation-property-input';
+
+defineDraggableNumber();
+definePropertyInput();
+defineRotationPropertyInput();
+
+const hasDom = typeof document !== 'undefined';
+(hasDom ? describe : describe.skip)('rotation-property-input', () => {
+    it('splits value into rotations and degrees', () => {
+        document.body.innerHTML = '<cc-rotation-property-input value="390"></cc-rotation-property-input>';
+        const comp = document.querySelector('cc-rotation-property-input') as any;
+        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as any;
+        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as any;
+
+        expect(rotations.value).toBe(1);
+        expect(degrees.value).toBe(30);
+    });
+
+    it('updates value when parts change', () => {
+        document.body.innerHTML = '<cc-rotation-property-input value="390"></cc-rotation-property-input>';
+        const comp = document.querySelector('cc-rotation-property-input') as any;
+        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as any;
+        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as any;
+
+        rotations.value = 2;
+        rotations.dispatchEvent(new Event('change'));
+        expect(comp.value).toBe(2 * 360 + 30);
+
+        degrees.value = 45;
+        degrees.dispatchEvent(new Event('change'));
+        expect(comp.value).toBe(2 * 360 + 45);
+    });
+});


### PR DESCRIPTION
## Summary
- implement `<cc-rotation-property-input>` and expose it from library
- document rotation input usage in README
- add unit tests for the new component

## Testing
- `npm run lint`
- `npm test`