### PR TITLE
Add keyboard support to draggable number

### DIFF
--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -20,6 +20,7 @@ export class DraggableNumber extends LitElement {
         return template(
             this.value,
             this._onChange.bind(this),
+            this._onKeyDown.bind(this),
             this._onPointerDown.bind(this),
             this._onPointerMove.bind(this),
             this._stopDrag.bind(this)
@@ -51,6 +52,18 @@ export class DraggableNumber extends LitElement {
         const input = e.target as HTMLInputElement;
         this._dragging = false;
         input.releasePointerCapture(e.pointerId);
+    }
+
+    private _onKeyDown(e: KeyboardEvent) {
+        if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
+            this.value += 1;
+            this.dispatchEvent(new Event('change'));
+            e.preventDefault();
+        } else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
+            this.value -= 1;
+            this.dispatchEvent(new Event('change'));
+            e.preventDefault();
+        }
     }
 }
 

--- a/src/components/draggable-number/style.css
+++ b/src/components/draggable-number/style.css
@@ -6,3 +6,8 @@
 input {
     width: 4rem;
 }
+
+input:focus {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}

--- a/src/components/draggable-number/template.ts
+++ b/src/components/draggable-number/template.ts
@@ -3,6 +3,7 @@ import { html } from 'lit';
 export const template = (
     value: number,
     onChange: (e: Event) => void,
+    onKeyDown: (e: KeyboardEvent) => void,
     onPointerDown: (e: PointerEvent) => void,
     onPointerMove: (e: PointerEvent) => void,
     onPointerUp: (e: PointerEvent) => void
@@ -10,6 +11,7 @@ export const template = (
     type="number"
     .value=${String(value)}
     @change=${onChange}
+    @keydown=${onKeyDown}
     @pointerdown=${onPointerDown}
     @pointermove=${onPointerMove}
     @pointerup=${onPointerUp}

--- a/tests/components.test.ts
+++ b/tests/components.test.ts
@@ -31,4 +31,19 @@ describe('DraggableNumber', () => {
         component['_stopDrag'](upEvent);
         expect(input.releasePointerCapture).toHaveBeenCalledWith(1);
     });
+
+    it('adjusts value with arrow keys', () => {
+        const component = new DraggableNumber();
+        component.value = 0;
+
+        const upEvent = { key: 'ArrowUp', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+        component['_onKeyDown'](upEvent);
+        expect(component.value).toBe(1);
+        expect(upEvent.preventDefault).toHaveBeenCalled();
+
+        const downEvent = { key: 'ArrowDown', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+        component['_onKeyDown'](downEvent);
+        expect(component.value).toBe(0);
+        expect(downEvent.preventDefault).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
## Summary
- allow cc-draggable-number to adjust value with arrow keys
- style input focus state
- update template to wire keydown
- test keyboard adjustments

## Testing
- `npm run lint`
- `npm test`
