### PR TITLE
Fix rotation input sign handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Linting is performed on both TypeScript and Rust code using ESLint, rustfmt and
 clippy. Install the Rust components with `rustup component add rustfmt clippy`.
 Run `npm run lint` to check formatting and common issues.
 
+## Draggable Number
+
+`<cc-draggable-number>` is an input that allows changing numerical values by
+clicking and dragging. It supports a `type` attribute that controls how the
+value is formatted and interpreted:
+
+- `raw` – the value is displayed as-is.
+- `whole-rotation` – shows the number of complete `360°` rotations of the
+  value.
+- `part-rotation` – shows the remaining degrees after removing complete
+  rotations.
+
 ## Rotation Property Input
 
 `<cc-rotation-property-input>` displays an angle as full rotations and partial degrees.

--- a/src/components/rotation-property-input/index.ts
+++ b/src/components/rotation-property-input/index.ts
@@ -15,27 +15,9 @@ export class RotationPropertyInput extends LitElement {
 
     value = 0;
 
-    private _split(value: number) {
-        const rotations = Math.trunc(value / 360);
-        const remainder = value - rotations * 360;
-        const sign = remainder >= 0 ? '+' : '-';
-        const degrees = Math.abs(remainder);
-        return { rotations, sign, degrees };
-    }
-
-    private _onRotationsChange(e: Event) {
-        const rot = (e.target as DraggableNumberElement).value;
-        const { sign, degrees } = this._split(this.value);
-        const signedDeg = sign === '-' ? -degrees : degrees;
-        this.value = rot * 360 + signedDeg;
-        this.dispatchEvent(new Event('change'));
-    }
-
-    private _onDegreesChange(e: Event) {
-        const deg = (e.target as DraggableNumberElement).value;
-        const { rotations, sign } = this._split(this.value);
-        const signedDeg = sign === '-' ? -deg : deg;
-        this.value = rotations * 360 + signedDeg;
+    private _onNumberChange(e: Event) {
+        const val = (e.target as DraggableNumberElement).value;
+        this.value = val;
         this.dispatchEvent(new Event('change'));
     }
 
@@ -46,13 +28,9 @@ export class RotationPropertyInput extends LitElement {
     }
 
     render() {
-        const { rotations, sign, degrees } = this._split(this.value);
         return template(
-            rotations,
-            sign,
-            degrees,
-            this._onRotationsChange.bind(this),
-            this._onDegreesChange.bind(this)
+            this.value,
+            this._onNumberChange.bind(this)
         );
     }
 }

--- a/src/components/rotation-property-input/template.ts
+++ b/src/components/rotation-property-input/template.ts
@@ -1,22 +1,21 @@
 import { html } from 'lit';
 
 export const template = (
-    rotations: number,
-    sign: string,
-    degrees: number,
-    onRotationsChange: (e: Event) => void,
-    onDegreesChange: (e: Event) => void
-) => html`<cc-property-input>
+    value: number,
+    onChange: (e: Event) => void
+) => html`<cc-property-input .value=${value}>
     <cc-draggable-number
         part="rotations"
-        .value=${rotations}
-        @change=${onRotationsChange}
+        .value=${value}
+        type="whole-rotation"
+        @change=${onChange}
     ></cc-draggable-number>
-    <span>x${sign}</span>
+    <span>x</span>
     <cc-draggable-number
         part="degrees"
-        .value=${degrees}
-        @change=${onDegreesChange}
+        .value=${value}
+        type="part-rotation"
+        @change=${onChange}
     ></cc-draggable-number>
     <span>°</span>
 </cc-property-input>`;

--- a/tests/rotation-property-input.test.ts
+++ b/tests/rotation-property-input.test.ts
@@ -9,14 +9,16 @@ defineRotationPropertyInput();
 
 const hasDom = typeof document !== 'undefined';
 (hasDom ? describe : describe.skip)('rotation-property-input', () => {
-    it('splits value into rotations and degrees', () => {
+    it('formats value into rotations and degrees', () => {
         document.body.innerHTML = '<cc-rotation-property-input value="390"></cc-rotation-property-input>';
         const comp = document.querySelector('cc-rotation-property-input') as any;
         const rotations = comp.shadowRoot.querySelector('[part=rotations]') as any;
         const degrees = comp.shadowRoot.querySelector('[part=degrees]') as any;
+        const rotInput = rotations.shadowRoot.querySelector('input') as HTMLInputElement;
+        const degInput = degrees.shadowRoot.querySelector('input') as HTMLInputElement;
 
-        expect(rotations.value).toBe(1);
-        expect(degrees.value).toBe(30);
+        expect(rotInput.value).toBe('1');
+        expect(degInput.value).toBe('30');
     });
 
     it('updates value when parts change', () => {
@@ -24,13 +26,15 @@ const hasDom = typeof document !== 'undefined';
         const comp = document.querySelector('cc-rotation-property-input') as any;
         const rotations = comp.shadowRoot.querySelector('[part=rotations]') as any;
         const degrees = comp.shadowRoot.querySelector('[part=degrees]') as any;
+        const rotInput = rotations.shadowRoot.querySelector('input') as HTMLInputElement;
+        const degInput = degrees.shadowRoot.querySelector('input') as HTMLInputElement;
 
-        rotations.value = 2;
-        rotations.dispatchEvent(new Event('change'));
+        rotInput.value = '2';
+        rotInput.dispatchEvent(new Event('change'));
         expect(comp.value).toBe(2 * 360 + 30);
 
-        degrees.value = 45;
-        degrees.dispatchEvent(new Event('change'));
+        degInput.value = '45';
+        degInput.dispatchEvent(new Event('change'));
         expect(comp.value).toBe(2 * 360 + 45);
     });
 });


### PR DESCRIPTION
## Summary
- add `DraggableNumberType` with `raw`, `whole-rotation`, and `part-rotation`
- handle formatting/parsing based on the `type` property
- update rotation property input to pass full value to draggable numbers
- document the new draggable number types

## Testing
- `npm run lint`
- `npm test`
