### PR TITLE
Relocate unit tests next to source

### DIFF
--- a/PROJECT-PLAN.md
+++ b/PROJECT-PLAN.md
@@ -364,8 +364,7 @@ cc-web-components/
 │   └── basic-demo/
 │       ├── index.html        # A simple HTML file demonstrating usage of our components
 │       └── main.ts           # Script to import the library and use it (if needed)
-├── tests/                     # Automated tests for components
-│   ├── components.test.ts    # Example test file for component behaviors
+├── tests/                     # Integration tests (if any)
 │   └── ...
 ├── readme-images/             # Images for the README documentation (screenshots, etc.)
 └── .github/
@@ -398,11 +397,9 @@ this during development (e.g., vite --open examples/basic-demo/index.html). This
 will also act as documentation by showing how to use the components (like including
 `<cc-draggable-number>` in HTML and perhaps using it with some script).
 
-The tests/ directory is for our automated tests. Depending on preference, we could intermix
-tests alongside source files (some like to put *.test.ts next to the component code).
-But having a separate tests/ folder is fine too. We will write tests for behaviors, e.g.,
-ensure that when you set a value on the component, it reflects correctly, or simulate a
-drag event and verify the outcome (if possible).
+Unit tests live next to the code they cover in `*.spec.ts` files. The `tests/` directory
+is reserved for future integration tests. Unit specs verify behaviors such as value
+synchronization or pointer dragging directly alongside the relevant component source.
 
 Finally, .github/workflows/ci.yml will contain the CI pipeline configuration for GitHub Actions.
 

--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { process_drag } from '../src/wasm-bindings/cc_web_components.js';
-import { DraggableNumber } from '../src/components/draggable-number/index.js';
-
-describe('process_drag', () => {
-    it('returns the delta value', () => {
-        expect(process_drag(5)).toBe(5);
-    });
-});
+import { DraggableNumber } from './index.js';
 
 describe('DraggableNumber', () => {
     it('releases pointer capture on pointerup', () => {

--- a/src/components/property-input/index.spec.ts
+++ b/src/components/property-input/index.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { defineDraggableNumber } from '../src/components/draggable-number';
-import { definePropertyInput } from '../src/components/property-input';
+import { defineDraggableNumber } from '../draggable-number';
+import { definePropertyInput } from './index';
 
 defineDraggableNumber();
 definePropertyInput();
@@ -15,10 +15,10 @@ const hasDom = typeof document !== 'undefined';
             </cc-property-input>
         `;
 
-        const container = document.querySelector('cc-property-input') as any;
+        const container = document.querySelector('cc-property-input') as HTMLElement & { value: number };
         const [first, second] = Array.from(
             container.querySelectorAll('cc-draggable-number')
-        ) as any[];
+        ) as (HTMLElement & { value: number })[];
 
         expect(first.value).toBe(5);
         expect(second.value).toBe(5);

--- a/src/components/rotation-property-input/index.spec.ts
+++ b/src/components/rotation-property-input/index.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { defineDraggableNumber } from '../src/components/draggable-number';
-import { definePropertyInput } from '../src/components/property-input';
-import { defineRotationPropertyInput } from '../src/components/rotation-property-input';
+import { defineDraggableNumber } from '../draggable-number';
+import { definePropertyInput } from '../property-input';
+import { defineRotationPropertyInput } from './index';
 
 defineDraggableNumber();
 definePropertyInput();
@@ -11,9 +11,9 @@ const hasDom = typeof document !== 'undefined';
 (hasDom ? describe : describe.skip)('rotation-property-input', () => {
     it('formats value into rotations and degrees', () => {
         document.body.innerHTML = '<cc-rotation-property-input value="390"></cc-rotation-property-input>';
-        const comp = document.querySelector('cc-rotation-property-input') as any;
-        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as any;
-        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as any;
+        const comp = document.querySelector('cc-rotation-property-input') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
+        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
+        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
         const rotInput = rotations.shadowRoot.querySelector('input') as HTMLInputElement;
         const degInput = degrees.shadowRoot.querySelector('input') as HTMLInputElement;
 
@@ -23,9 +23,9 @@ const hasDom = typeof document !== 'undefined';
 
     it('updates value when parts change', () => {
         document.body.innerHTML = '<cc-rotation-property-input value="390"></cc-rotation-property-input>';
-        const comp = document.querySelector('cc-rotation-property-input') as any;
-        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as any;
-        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as any;
+        const comp = document.querySelector('cc-rotation-property-input') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
+        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
+        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
         const rotInput = rotations.shadowRoot.querySelector('input') as HTMLInputElement;
         const degInput = degrees.shadowRoot.querySelector('input') as HTMLInputElement;
 

--- a/src/wasm-bindings/cc_web_components.spec.ts
+++ b/src/wasm-bindings/cc_web_components.spec.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { process_drag } from './cc_web_components.js';
+
+describe('process_drag', () => {
+    it('returns the delta value', () => {
+        expect(process_drag(5)).toBe(5);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
         "forceConsistentCasingInFileNames": true,
         "outDir": "dist/types"
     },
-    "include": ["src/**/*", "tests/**/*"],
+    "include": ["src/**/*"],
     "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- move tests from `/tests` directory to live beside source files
- rename unit test files to `*.spec.ts`
- adjust imports for new file locations
- remove old test folder from tsconfig
- document new test layout in PROJECT-PLAN

## Testing
- `npm run lint`
- `npm test`