### PR TITLE
Add editing state to DraggableNumber

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { DraggableNumber } from './index.js';
+import { DraggableNumber, defineDraggableNumber } from './index.js';
 
 describe('DraggableNumber', () => {
     it('releases pointer capture on pointerup', () => {
@@ -38,5 +38,21 @@ describe('DraggableNumber', () => {
         component['_onKeyDown'](downEvent);
         expect(component.value).toBe(0);
         expect(downEvent.preventDefault).toHaveBeenCalled();
+    });
+});
+
+defineDraggableNumber();
+const hasDom = typeof document !== 'undefined';
+(hasDom ? describe : describe.skip)('draggable-number DOM', () => {
+    it('shows input after click', async () => {
+        document.body.innerHTML = '<cc-draggable-number></cc-draggable-number>';
+        const comp = document.querySelector('cc-draggable-number') as HTMLElement & { shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        expect(comp.shadowRoot.querySelector('span')).not.toBeNull();
+        expect(comp.shadowRoot.querySelector('input')).toBeNull();
+        const span = comp.shadowRoot.querySelector('span') as HTMLElement;
+        span.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await comp.updateComplete;
+        expect(comp.shadowRoot.querySelector('input')).not.toBeNull();
     });
 });

--- a/src/components/draggable-number/style.css
+++ b/src/components/draggable-number/style.css
@@ -3,8 +3,15 @@
     cursor: ew-resize;
 }
 
+span {
+    user-select: none;
+}
+
 input {
     width: 4rem;
+    position: absolute;
+    top: 0;
+    left: 0;
 }
 
 input:focus {

--- a/src/components/draggable-number/template.ts
+++ b/src/components/draggable-number/template.ts
@@ -2,18 +2,30 @@ import { html } from 'lit';
 
 export const template = (
     value: number,
-    onChange: (e: Event) => void,
+    editing: boolean,
+    onBlur: (e: Event) => void,
     onKeyDown: (e: KeyboardEvent) => void,
     onPointerDown: (e: PointerEvent) => void,
     onPointerMove: (e: PointerEvent) => void,
-    onPointerUp: (e: PointerEvent) => void
-) => html`<input
-    type="number"
-    .value=${String(value)}
-    @change=${onChange}
-    @keydown=${onKeyDown}
-    @pointerdown=${onPointerDown}
-    @pointermove=${onPointerMove}
-    @pointerup=${onPointerUp}
-    @pointercancel=${onPointerUp}
-/>`;
+    onPointerUp: (e: PointerEvent) => void,
+    onClick: () => void
+) => html`
+    <span
+        tabindex="0"
+        @click=${onClick}
+        @keydown=${onKeyDown}
+        @pointerdown=${onPointerDown}
+        @pointermove=${onPointerMove}
+        @pointerup=${onPointerUp}
+        @pointercancel=${onPointerUp}
+        >${value}</span
+    >
+    ${editing
+        ? html`<input
+              type="number"
+              .value=${String(value)}
+              @blur=${onBlur}
+              @keydown=${onKeyDown}
+          />`
+        : null}
+`;


### PR DESCRIPTION
## Summary
- adjust DraggableNumber editing logic so editing state is internal
- stop sending pointer handlers to the input element
- remove relative positioning from the component style

## Testing
- `npm run lint`
- `npm test`
