### PR TITLE
Add relative positioning to property-input host

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ value is formatted and interpreted:
 - `part-rotation` – shows the remaining degrees after removing complete
   rotations.
 
+The overlay input used when editing is absolutely positioned, so place
+`cc-draggable-number` inside a relatively positioned container to keep the
+overlay aligned.
+
 ## Rotation Property Input
 
 `<cc-rotation-property-input>` displays an angle as full rotations and partial degrees.

--- a/src/components/property-input/style.css
+++ b/src/components/property-input/style.css
@@ -1,3 +1,4 @@
 :host {
     display: inline-block;
+    position: relative;
 }


### PR DESCRIPTION
## Summary
- ensure `cc-property-input` host is relatively positioned
- document overlay positioning requirement for `cc-draggable-number`

## Testing
- `npm test`
- `npm run lint`
