### PR TITLE
Enable jsdom for DOM tests

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -42,8 +42,7 @@ describe('DraggableNumber', () => {
 });
 
 defineDraggableNumber();
-const hasDom = typeof document !== 'undefined';
-(hasDom ? describe : describe.skip)('draggable-number DOM', () => {
+describe('draggable-number DOM', () => {
     it('shows input after click', async () => {
         document.body.innerHTML = '<cc-draggable-number></cc-draggable-number>';
         const comp = document.querySelector('cc-draggable-number') as HTMLElement & { shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -18,8 +18,18 @@ export class DraggableNumber extends LitElement {
     private _startValue = 0;
     private _startX = 0;
 
-    value = 0;
-    type: DraggableNumberType = 'raw';
+    declare value: number;
+    declare type: DraggableNumberType;
+
+    constructor() {
+        super();
+        if (!this.hasAttribute('value')) {
+            this.value = 0;
+        }
+        if (!this.hasAttribute('type')) {
+            this.type = 'raw';
+        }
+    }
 
     private _editing = false;
 

--- a/src/components/property-input/index.spec.ts
+++ b/src/components/property-input/index.spec.ts
@@ -5,9 +5,8 @@ import { definePropertyInput } from './index';
 defineDraggableNumber();
 definePropertyInput();
 
-const hasDom = typeof document !== 'undefined';
-(hasDom ? describe : describe.skip)('property-input', () => {
-    it('syncs value between nested draggable numbers', () => {
+describe('property-input', () => {
+    it('syncs value between nested draggable numbers', async () => {
         document.body.innerHTML = `
             <cc-property-input value="5">
                 <cc-draggable-number></cc-draggable-number>
@@ -15,10 +14,11 @@ const hasDom = typeof document !== 'undefined';
             </cc-property-input>
         `;
 
-        const container = document.querySelector('cc-property-input') as HTMLElement & { value: number };
+        const container = document.querySelector('cc-property-input') as HTMLElement & { value: number; updateComplete: Promise<unknown> };
+        await container.updateComplete;
         const [first, second] = Array.from(
             container.querySelectorAll('cc-draggable-number')
-        ) as (HTMLElement & { value: number })[];
+        ) as (HTMLElement & { value: number; updateComplete: Promise<unknown> })[];
 
         expect(first.value).toBe(5);
         expect(second.value).toBe(5);
@@ -28,6 +28,9 @@ const hasDom = typeof document !== 'undefined';
 
         first.value = 12;
         first.dispatchEvent(new Event('change'));
+        await container.updateComplete;
+        await first.updateComplete;
+        await second.updateComplete;
 
         expect(container.value).toBe(12);
         expect(second.value).toBe(12);

--- a/src/components/property-input/index.ts
+++ b/src/components/property-input/index.ts
@@ -11,7 +11,14 @@ export class PropertyInput extends LitElement {
         value: { type: Number, reflect: true }
     };
 
-    value = 0;
+    declare value: number;
+
+    constructor() {
+        super();
+        if (!this.hasAttribute('value')) {
+            this.value = 0;
+        }
+    }
 
     private _listeners = new Map<DraggableNumberElement, EventListener>();
 

--- a/src/components/rotation-property-input/index.spec.ts
+++ b/src/components/rotation-property-input/index.spec.ts
@@ -7,34 +7,38 @@ defineDraggableNumber();
 definePropertyInput();
 defineRotationPropertyInput();
 
-const hasDom = typeof document !== 'undefined';
-(hasDom ? describe : describe.skip)('rotation-property-input', () => {
-    it('formats value into rotations and degrees', () => {
+describe('rotation-property-input', () => {
+    it('formats value into rotations and degrees', async () => {
         document.body.innerHTML = '<cc-rotation-property-input value="390"></cc-rotation-property-input>';
-        const comp = document.querySelector('cc-rotation-property-input') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
-        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
-        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
-        const rotInput = rotations.shadowRoot.querySelector('input') as HTMLInputElement;
-        const degInput = degrees.shadowRoot.querySelector('input') as HTMLInputElement;
+        const comp = document.querySelector('cc-rotation-property-input') as HTMLElement & { value: number; shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as HTMLElement & { value: number; shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as HTMLElement & { value: number; shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await rotations.updateComplete;
+        await degrees.updateComplete;
+        const rotSpan = rotations.shadowRoot.querySelector('span') as HTMLElement;
+        const degSpan = degrees.shadowRoot.querySelector('span') as HTMLElement;
 
-        expect(rotInput.value).toBe('1');
-        expect(degInput.value).toBe('30');
+        expect(rotSpan.textContent).toBe('1');
+        expect(degSpan.textContent).toBe('30');
     });
 
-    it('updates value when parts change', () => {
+    it('updates value when parts change', async () => {
         document.body.innerHTML = '<cc-rotation-property-input value="390"></cc-rotation-property-input>';
-        const comp = document.querySelector('cc-rotation-property-input') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
-        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
-        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as HTMLElement & { value: number; shadowRoot: ShadowRoot };
-        const rotInput = rotations.shadowRoot.querySelector('input') as HTMLInputElement;
-        const degInput = degrees.shadowRoot.querySelector('input') as HTMLInputElement;
-
-        rotInput.value = '2';
-        rotInput.dispatchEvent(new Event('change'));
+        const comp = document.querySelector('cc-rotation-property-input') as HTMLElement & { value: number; shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as HTMLElement & { value: number; shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as HTMLElement & { value: number; shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await rotations.updateComplete;
+        await degrees.updateComplete;
+        rotations.value = 2 * 360 + 30;
+        rotations.dispatchEvent(new Event('change'));
+        await comp.updateComplete;
         expect(comp.value).toBe(2 * 360 + 30);
 
-        degInput.value = '45';
-        degInput.dispatchEvent(new Event('change'));
+        degrees.value = 2 * 360 + 45;
+        degrees.dispatchEvent(new Event('change'));
+        await comp.updateComplete;
         expect(comp.value).toBe(2 * 360 + 45);
     });
 });

--- a/src/components/rotation-property-input/index.ts
+++ b/src/components/rotation-property-input/index.ts
@@ -13,7 +13,14 @@ export class RotationPropertyInput extends LitElement {
         value: { type: Number, reflect: true }
     };
 
-    value = 0;
+    declare value: number;
+
+    constructor() {
+        super();
+        if (!this.hasAttribute('value')) {
+            this.value = 0;
+        }
+    }
 
     private _onNumberChange(e: Event) {
         const val = (e.target as DraggableNumberElement).value;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "esModuleInterop": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
-        "outDir": "dist/types"
+        "outDir": "dist/types",
+        "types": ["vitest", "jsdom"]
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "dist"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,5 +15,9 @@ export default defineConfig({
                 globals: {}
             }
         }
+    },
+    test: {
+        environment: 'jsdom',
+        setupFiles: './vitest.setup.ts'
     }
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+(globalThis as any).litDisableDevMode = true;


### PR DESCRIPTION
## Summary
- use jsdom for Vitest
- stop skipping DOM tests
- adjust DOM tests to work with jsdom
- fix LitElement initialization to avoid dev errors

## Testing
- `npm run lint`
- `npm test`
- `cargo test`
