### PR TITLE
Focus draggable number input

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -143,4 +143,17 @@ describe('draggable-number DOM', () => {
         await comp.updateComplete;
         expect(comp.shadowRoot.querySelector('input')).not.toBeNull();
     });
+
+    it('focuses and selects the input on edit start', async () => {
+        document.body.innerHTML = '<cc-draggable-number value="42"></cc-draggable-number>';
+        const comp = document.querySelector('cc-draggable-number') as HTMLElement & { shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        const selectSpy = vi.spyOn(HTMLInputElement.prototype, 'select');
+        const span = comp.shadowRoot.querySelector('span') as HTMLElement;
+        span.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await comp.updateComplete;
+        const input = comp.shadowRoot.querySelector('input') as HTMLInputElement;
+        expect(comp.shadowRoot.activeElement).toBe(input);
+        expect(selectSpy).toHaveBeenCalled();
+    });
 });

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -43,6 +43,19 @@ export class DraggableNumber extends LitElement {
         this.requestUpdate('editing', old);
     }
 
+    updated(changed: Map<string, unknown>) {
+        super.updated(changed);
+        if (changed.has('editing') && this.editing) {
+            const input = this.shadowRoot?.querySelector('input');
+            if (input) {
+                input.focus();
+                if (typeof input.select === 'function') {
+                    input.select();
+                }
+            }
+        }
+    }
+
     render() {
         return template(
             this._formatValue(),


### PR DESCRIPTION
## Summary
- focus and select text in the draggable number's input when editing begins
- test DOM behavior for focusing and selection

## Testing
- `npm test`
- `npm run lint`
