### PR TITLE
Implement span refocus after editing

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -132,6 +132,13 @@ describe('DraggableNumber', () => {
 
 defineDraggableNumber();
 describe('draggable-number DOM', () => {
+    it('span is focusable', async () => {
+        document.body.innerHTML = '<cc-draggable-number></cc-draggable-number>';
+        const comp = document.querySelector('cc-draggable-number') as HTMLElement & { shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        const span = comp.shadowRoot.querySelector('span');
+        expect(span?.getAttribute('tabindex')).toBe('0');
+    });
     it('shows input after click', async () => {
         document.body.innerHTML = '<cc-draggable-number></cc-draggable-number>';
         const comp = document.querySelector('cc-draggable-number') as HTMLElement & { shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
@@ -155,5 +162,35 @@ describe('draggable-number DOM', () => {
         const input = comp.shadowRoot.querySelector('input') as HTMLInputElement;
         expect(comp.shadowRoot.activeElement).toBe(input);
         expect(selectSpy).toHaveBeenCalled();
+    });
+
+    it('refocuses the span on keyboard exit', async () => {
+        document.body.innerHTML = '<cc-draggable-number value="42"></cc-draggable-number>';
+        const comp = document.querySelector('cc-draggable-number') as HTMLElement & { shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        const span = comp.shadowRoot.querySelector('span') as HTMLElement;
+        span.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await comp.updateComplete;
+        const input = comp.shadowRoot.querySelector('input') as HTMLInputElement;
+        const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+        input.dispatchEvent(event);
+        await comp.updateComplete;
+        expect(comp.shadowRoot.querySelector('input')).toBeNull();
+        const newSpan = comp.shadowRoot.querySelector('span') as HTMLElement;
+        expect(comp.shadowRoot.activeElement).toBe(newSpan);
+    });
+
+    it('does not refocus the span when blurred', async () => {
+        document.body.innerHTML = '<cc-draggable-number value="42"></cc-draggable-number>';
+        const comp = document.querySelector('cc-draggable-number') as HTMLElement & { shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        const span = comp.shadowRoot.querySelector('span') as HTMLElement;
+        span.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await comp.updateComplete;
+        const input = comp.shadowRoot.querySelector('input') as HTMLInputElement;
+        input.dispatchEvent(new Event('blur', { bubbles: true }));
+        await comp.updateComplete;
+        const newSpan = comp.shadowRoot.querySelector('span') as HTMLElement;
+        expect(comp.shadowRoot.activeElement).not.toBe(newSpan);
     });
 });

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -32,6 +32,7 @@ export class DraggableNumber extends LitElement {
     }
 
     private _editing = false;
+    private _focusDisplayNext = false;
 
     get editing() {
         return this._editing;
@@ -45,13 +46,19 @@ export class DraggableNumber extends LitElement {
 
     updated(changed: Map<string, unknown>) {
         super.updated(changed);
-        if (changed.has('editing') && this.editing) {
-            const input = this.shadowRoot?.querySelector('input');
-            if (input) {
-                input.focus();
-                if (typeof input.select === 'function') {
-                    input.select();
+        if (changed.has('editing')) {
+            if (this.editing) {
+                const input = this.shadowRoot?.querySelector('input');
+                if (input) {
+                    input.focus();
+                    if (typeof input.select === 'function') {
+                        input.select();
+                    }
                 }
+            } else if (this._focusDisplayNext) {
+                const span = this.shadowRoot?.querySelector('span');
+                span?.focus();
+                this._focusDisplayNext = false;
             }
         }
     }
@@ -146,6 +153,7 @@ export class DraggableNumber extends LitElement {
         if (this.editing) {
             if (e.key === 'Enter' || e.key === 'Escape') {
                 const input = e.target as HTMLInputElement;
+                this._focusDisplayNext = true;
                 this._onBlur({ target: input } as Event);
                 e.preventDefault();
             }


### PR DESCRIPTION
## Summary
- focus draggable-number span on keyboard exit
- test focusing behaviour after editing
- verify span is focusable

## Testing
- `npm run lint`
- `npm test`
