### PR TITLE
Add percent type to draggable number

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ value is formatted and interpreted:
   value.
 - `part-rotation` – shows the remaining degrees after removing complete
   rotations.
+- `percent` – displays the value multiplied by `100` and parses input as a
+  percentage.
 
 The overlay input used when editing is absolutely positioned, so place
 `cc-draggable-number` inside a relatively positioned container to keep the
@@ -92,8 +94,18 @@ and `D` is the remaining degrees. Internally it uses `cc-property-input` with tw
 ```
 
 The example above renders the value as `1x+30°`.
+## Percent Property Input
 
+`<cc-percent-property-input>` displays a numeric value as a percentage.
+The component maps its internal value from the range `0`–`1` to display
+`0`–`100` without clamping. Internally it uses `cc-property-input` with a
+single `cc-draggable-number` element configured with `type="percent"`.
 
+```html
+<cc-percent-property-input value="0.35"></cc-percent-property-input>
+```
+
+The example above renders the value as `35%`.
 ## Project Plan
 
 For the full development plan and design details, see [PROJECT-PLAN.md](./PROJECT-PLAN.md).

--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -96,6 +96,15 @@ describe('DraggableNumber', () => {
         expect(component.value).toBe(360);
     });
 
+    it('formats and parses percent type', () => {
+        const component = new DraggableNumber();
+        component.type = 'percent';
+        component.value = 0.5;
+        expect((component as unknown as { _formatValue(): number })._formatValue()).toBe(50);
+        const parsed = (component as unknown as { _parseValue(n: number): number })._parseValue(75);
+        expect(parsed).toBeCloseTo(0.75);
+    });
+
     it('tracks movement when pointer is locked', () => {
         const component = new DraggableNumber();
         const target = {

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -3,7 +3,11 @@ import componentStyles from './style.css?inline';
 import { template } from './template';
 import { process_drag } from '../../wasm-bindings/cc_web_components.js';
 
-export type DraggableNumberType = 'raw' | 'whole-rotation' | 'part-rotation';
+export type DraggableNumberType =
+    | 'raw'
+    | 'whole-rotation'
+    | 'part-rotation'
+    | 'percent';
 
 export class DraggableNumber extends LitElement {
     static styles = css`${unsafeCSS(componentStyles)}`;
@@ -126,6 +130,9 @@ export class DraggableNumber extends LitElement {
             const rotations = Math.trunc(this.value / 360);
             return this.value - rotations * 360;
         }
+        if (this.type === 'percent') {
+            return this.value * 100;
+        }
         return this.value;
     }
 
@@ -137,6 +144,9 @@ export class DraggableNumber extends LitElement {
         if (this.type === 'part-rotation') {
             const rotations = Math.trunc(this.value / 360);
             return rotations * 360 + input;
+        }
+        if (this.type === 'percent') {
+            return input / 100;
         }
         return input;
     }

--- a/src/components/percent-property-input/index.spec.ts
+++ b/src/components/percent-property-input/index.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { defineDraggableNumber } from '../draggable-number';
+import { definePropertyInput } from '../property-input';
+import { definePercentPropertyInput } from './index';
+
+defineDraggableNumber();
+definePropertyInput();
+definePercentPropertyInput();
+
+describe('percent-property-input', () => {
+    it('formats value into percent', async () => {
+        document.body.innerHTML = '<cc-percent-property-input value="0.35"></cc-percent-property-input>';
+        const comp = document.querySelector('cc-percent-property-input') as HTMLElement & { value: number; shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        const percent = comp.shadowRoot.querySelector('[part=percent]') as HTMLElement & { value: number; shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await percent.updateComplete;
+        const span = percent.shadowRoot.querySelector('span') as HTMLElement;
+        expect(span.textContent).toBe('35');
+    });
+
+    it('updates value when percent changes', async () => {
+        document.body.innerHTML = '<cc-percent-property-input value="0.35"></cc-percent-property-input>';
+        const comp = document.querySelector('cc-percent-property-input') as HTMLElement & { value: number; shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        const percent = comp.shadowRoot.querySelector('[part=percent]') as HTMLElement & { value: number; updateComplete: Promise<unknown> };
+        percent.value = 0.45;
+        percent.dispatchEvent(new Event('change'));
+        await comp.updateComplete;
+        expect(comp.value).toBeCloseTo(0.45);
+    });
+});

--- a/src/components/percent-property-input/index.ts
+++ b/src/components/percent-property-input/index.ts
@@ -1,0 +1,46 @@
+import { LitElement, css, unsafeCSS } from 'lit';
+import componentStyles from './style.css?inline';
+import { template } from './template';
+import { defineDraggableNumber } from '../draggable-number';
+import { definePropertyInput } from '../property-input';
+
+type DraggableNumberElement = HTMLElement & { value: number };
+
+export class PercentPropertyInput extends LitElement {
+    static styles = css`${unsafeCSS(componentStyles)}`;
+
+    static properties = {
+        value: { type: Number, reflect: true }
+    };
+
+    declare value: number;
+
+    constructor() {
+        super();
+        if (!this.hasAttribute('value')) {
+            this.value = 0;
+        }
+    }
+
+    private _onNumberChange(e: Event) {
+        const val = (e.target as DraggableNumberElement).value;
+        this.value = val;
+        this.dispatchEvent(new Event('change'));
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        definePropertyInput();
+        defineDraggableNumber();
+    }
+
+    render() {
+        return template(this.value, this._onNumberChange.bind(this));
+    }
+}
+
+export function definePercentPropertyInput() {
+    if (!customElements.get('cc-percent-property-input')) {
+        customElements.define('cc-percent-property-input', PercentPropertyInput);
+    }
+}

--- a/src/components/percent-property-input/style.css
+++ b/src/components/percent-property-input/style.css
@@ -1,0 +1,3 @@
+:host {
+    display: inline-block;
+}

--- a/src/components/percent-property-input/template.ts
+++ b/src/components/percent-property-input/template.ts
@@ -1,0 +1,14 @@
+import { html } from 'lit';
+
+export const template = (
+    value: number,
+    onChange: (e: Event) => void
+) => html`<cc-property-input .value=${value}>
+    <cc-draggable-number
+        part="percent"
+        .value=${value}
+        type="percent"
+        @change=${onChange}
+    ></cc-draggable-number>
+    <span>%</span>
+</cc-property-input>`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,14 @@
 import { defineDraggableNumber } from './components/draggable-number';
 import { definePropertyInput } from './components/property-input';
 import { defineRotationPropertyInput } from './components/rotation-property-input';
+import { definePercentPropertyInput } from './components/percent-property-input';
 
 defineDraggableNumber();
 definePropertyInput();
 defineRotationPropertyInput();
+definePercentPropertyInput();
 
 export * from './components/draggable-number';
 export * from './components/property-input';
 export * from './components/rotation-property-input';
+export * from './components/percent-property-input';


### PR DESCRIPTION
## Summary
- support `percent` type in `cc-draggable-number`
- use the new type within `percent-property-input`
- document usage of the `percent` type
- test percent formatting and parsing

## Testing
- `npm run lint`
- `npm test`
