### PR TITLE
Fix percent drag/keyboard scaling

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -50,6 +50,22 @@ describe('DraggableNumber', () => {
         expect(downEvent.preventDefault).toHaveBeenCalled();
     });
 
+    it('adjusts percent type with arrow keys', () => {
+        const component = new DraggableNumber();
+        component.type = 'percent';
+        component.value = 0;
+
+        const upEvent = { key: 'ArrowUp', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+        component['_onKeyDown'](upEvent);
+        expect(component.value).toBeCloseTo(0.01);
+        expect(upEvent.preventDefault).toHaveBeenCalled();
+
+        const downEvent = { key: 'ArrowDown', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+        component['_onKeyDown'](downEvent);
+        expect(component.value).toBeCloseTo(0);
+        expect(downEvent.preventDefault).toHaveBeenCalled();
+    });
+
     it('updates value and exits editing on blur', () => {
         const component = new DraggableNumber();
         component['_setEditing'](true);
@@ -94,6 +110,15 @@ describe('DraggableNumber', () => {
         component['_onPointerDown']({ target, clientX: 0, pointerId: 1 } as PointerEvent);
         component['_onPointerMove']({ clientX: 1 } as PointerEvent);
         expect(component.value).toBe(360);
+    });
+
+    it('scales drag change for percent type', () => {
+        const component = new DraggableNumber();
+        component.type = 'percent';
+        const target = { setPointerCapture: vi.fn() } as unknown as HTMLElement;
+        component['_onPointerDown']({ target, clientX: 0, pointerId: 1 } as PointerEvent);
+        component['_onPointerMove']({ clientX: 1 } as PointerEvent);
+        expect(component.value).toBeCloseTo(0.01);
     });
 
     it('formats and parses percent type', () => {

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -117,6 +117,8 @@ export class DraggableNumber extends LitElement {
         let change = process_drag(delta);
         if (this.type === 'whole-rotation') {
             change *= 360;
+        } else if (this.type === 'percent') {
+            change /= 100;
         }
         this.value = this._startValue + change;
         this.dispatchEvent(new Event('change'));
@@ -183,11 +185,13 @@ export class DraggableNumber extends LitElement {
             this._setEditing(true);
             e.preventDefault();
         } else if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
-            this.value += 1;
+            const increment = this.type === 'percent' ? 0.01 : 1;
+            this.value += increment;
             this.dispatchEvent(new Event('change'));
             e.preventDefault();
         } else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
-            this.value -= 1;
+            const increment = this.type === 'percent' ? 0.01 : 1;
+            this.value -= increment;
             this.dispatchEvent(new Event('change'));
             e.preventDefault();
         }


### PR DESCRIPTION
## Summary
- support scaling for percent draggable number by dividing drag delta and using 0.01 arrow increments
- add tests for percent drag and keyboard behavior

## Testing
- `npm run lint`
- `npm test`
