### PR TITLE
Fix start position reset for draggable-number

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -87,6 +87,15 @@ describe('DraggableNumber', () => {
         expect(dispatch).toHaveBeenCalled();
     });
 
+    it('resets start position after each move without pointer lock', () => {
+        const component = new DraggableNumber();
+        component.value = 0;
+        const target = { setPointerCapture: vi.fn() } as unknown as HTMLElement;
+        component['_onPointerDown']({ target, clientX: 100, pointerId: 1 } as PointerEvent);
+        component['_onPointerMove']({ clientX: 110 } as PointerEvent);
+        expect((component as unknown as { _startX: number })._startX).toBe(110);
+    });
+
     it('scales drag change for whole rotations', () => {
         const component = new DraggableNumber();
         component.type = 'whole-rotation';

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -107,18 +107,28 @@ export class DraggableNumber extends LitElement {
     private _onPointerMove(e: PointerEvent) {
         if (!this._dragging) return;
         let delta: number;
-        if (typeof document !== 'undefined' && document.pointerLockElement) {
+        const hasLock =
+            typeof document !== 'undefined' && document.pointerLockElement;
+        if (hasLock) {
             this._lockDelta += e.movementX;
             delta = this._lockDelta;
         } else {
             delta = e.clientX - this._startX;
         }
+
         if (delta !== 0) this._moved = true;
         let change = process_drag(delta);
         if (this.type === 'whole-rotation') {
             change *= 360;
         }
-        this.value = this._startValue + change;
+
+        if (hasLock) {
+            this.value = this._startValue + change;
+        } else {
+            this.value += change;
+            this._startValue = this.value;
+            this._startX = e.clientX;
+        }
         this.dispatchEvent(new Event('change'));
     }
 


### PR DESCRIPTION
## Summary
- update drag handling logic when pointer lock isn't active
- test resetting the drag start position
- refactor pointer move handler to avoid duplicated code

## Testing
- `npm run lint`
- `npm test`
