### PR TITLE
Ensure sign for part-rotation formatted values

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -100,9 +100,18 @@ describe('DraggableNumber', () => {
         const component = new DraggableNumber();
         component.type = 'percent';
         component.value = 0.5;
-        expect((component as unknown as { _formatValue(): number })._formatValue()).toBe(50);
+        expect((component as unknown as { _formatValue(): string | number })._formatValue()).toBe(50);
         const parsed = (component as unknown as { _parseValue(n: number): number })._parseValue(75);
         expect(parsed).toBeCloseTo(0.75);
+    });
+
+    it('formats part rotations with a sign', () => {
+        const component = new DraggableNumber();
+        component.type = 'part-rotation';
+        component.value = 30;
+        expect((component as unknown as { _formatValue(): string | number })._formatValue()).toBe('+30');
+        component.value = -15;
+        expect((component as unknown as { _formatValue(): string | number })._formatValue()).toBe('-15');
     });
 
     it('tracks movement when pointer is locked', () => {

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -122,13 +122,15 @@ export class DraggableNumber extends LitElement {
         this.dispatchEvent(new Event('change'));
     }
 
-    private _formatValue(): number {
+    private _formatValue(): string | number {
         if (this.type === 'whole-rotation') {
             return Math.trunc(this.value / 360);
         }
         if (this.type === 'part-rotation') {
             const rotations = Math.trunc(this.value / 360);
-            return this.value - rotations * 360;
+            const val = this.value - rotations * 360;
+            const sign = val >= 0 ? '+' : '-';
+            return `${sign}${Math.abs(val)}`;
         }
         if (this.type === 'percent') {
             return this.value * 100;

--- a/src/components/draggable-number/template.ts
+++ b/src/components/draggable-number/template.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 
 export const template = (
-    value: number,
+    value: string | number,
     editing: boolean,
     onBlur: (e: Event) => void,
     onKeyDown: (e: KeyboardEvent) => void,

--- a/src/components/rotation-property-input/index.spec.ts
+++ b/src/components/rotation-property-input/index.spec.ts
@@ -20,7 +20,7 @@ describe('rotation-property-input', () => {
         const degSpan = degrees.shadowRoot.querySelector('span') as HTMLElement;
 
         expect(rotSpan.textContent).toBe('1');
-        expect(degSpan.textContent).toBe('30');
+        expect(degSpan.textContent).toBe('+30');
     });
 
     it('updates value when parts change', async () => {


### PR DESCRIPTION
## Summary
- show +/- sign when displaying part rotation values
- update tests for the new formatting

## Testing
- `npm run lint`
- `npm run test`