### PR TITLE
Add min and max bounds to draggable numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ value is formatted and interpreted:
 - `percent` – displays the value multiplied by `100` and parses input as a
   percentage.
 
+Optional `min` and `max` attributes can constrain the value. When omitted,
+no bounds are applied.
+
 The overlay input used when editing is absolutely positioned, so place
 `cc-draggable-number` inside a relatively positioned container to keep the
 overlay aligned.
@@ -88,6 +91,7 @@ overlay aligned.
 The value is shown in the format `Nx±D°`, where `N` is the number of full `360°` rotations
 and `D` is the remaining degrees. Internally it uses `cc-property-input` with two nested
 `cc-draggable-number` elements.
+`min` and `max` attributes are forwarded to both numbers.
 
 ```html
 <cc-rotation-property-input value="390"></cc-rotation-property-input>
@@ -100,6 +104,7 @@ The example above renders the value as `1x+30°`.
 The component maps its internal value from the range `0`–`1` to display
 `0`–`100` without clamping. Internally it uses `cc-property-input` with a
 single `cc-draggable-number` element configured with `type="percent"`.
+`min` and `max` attributes are passed through to that element.
 
 ```html
 <cc-percent-property-input value="0.35"></cc-percent-property-input>

--- a/src/components/draggable-number/template.ts
+++ b/src/components/draggable-number/template.ts
@@ -8,7 +8,9 @@ export const template = (
     onPointerDown: (e: PointerEvent) => void,
     onPointerMove: (e: PointerEvent) => void,
     onPointerUp: (e: PointerEvent) => void,
-    onClick: () => void
+    onClick: () => void,
+    min: number | null,
+    max: number | null
 ) => html`
     <span
         tabindex="0"
@@ -24,6 +26,8 @@ export const template = (
         ? html`<input
               type="number"
               .value=${String(value)}
+              .min=${min === null ? '' : String(min)}
+              .max=${max === null ? '' : String(max)}
               @blur=${onBlur}
               @keydown=${onKeyDown}
           />`

--- a/src/components/percent-property-input/index.spec.ts
+++ b/src/components/percent-property-input/index.spec.ts
@@ -28,4 +28,21 @@ describe('percent-property-input', () => {
         await comp.updateComplete;
         expect(comp.value).toBeCloseTo(0.45);
     });
+
+    it('forwards min and max to the draggable number', async () => {
+        document.body.innerHTML = '<cc-percent-property-input min="0" max="1"></cc-percent-property-input>';
+        const comp = document.querySelector('cc-percent-property-input') as HTMLElement & {
+            shadowRoot: ShadowRoot;
+            updateComplete: Promise<unknown>;
+        };
+        await comp.updateComplete;
+        const percent = comp.shadowRoot.querySelector('[part=percent]') as HTMLElement & {
+            min: number | null;
+            max: number | null;
+            updateComplete: Promise<unknown>;
+        };
+        await percent.updateComplete;
+        expect(percent.min).toBe(0);
+        expect(percent.max).toBe(1);
+    });
 });

--- a/src/components/percent-property-input/index.ts
+++ b/src/components/percent-property-input/index.ts
@@ -10,15 +10,25 @@ export class PercentPropertyInput extends LitElement {
     static styles = css`${unsafeCSS(componentStyles)}`;
 
     static properties = {
-        value: { type: Number, reflect: true }
+        value: { type: Number, reflect: true },
+        min: { type: Number, reflect: true },
+        max: { type: Number, reflect: true }
     };
 
     declare value: number;
+    declare min: number | null;
+    declare max: number | null;
 
     constructor() {
         super();
         if (!this.hasAttribute('value')) {
             this.value = 0;
+        }
+        if (!this.hasAttribute('min')) {
+            this.min = null;
+        }
+        if (!this.hasAttribute('max')) {
+            this.max = null;
         }
     }
 
@@ -35,7 +45,12 @@ export class PercentPropertyInput extends LitElement {
     }
 
     render() {
-        return template(this.value, this._onNumberChange.bind(this));
+        return template(
+            this.value,
+            this._onNumberChange.bind(this),
+            this.min,
+            this.max
+        );
     }
 }
 

--- a/src/components/percent-property-input/template.ts
+++ b/src/components/percent-property-input/template.ts
@@ -2,12 +2,16 @@ import { html } from 'lit';
 
 export const template = (
     value: number,
-    onChange: (e: Event) => void
+    onChange: (e: Event) => void,
+    min: number | null,
+    max: number | null
 ) => html`<cc-property-input .value=${value}>
     <cc-draggable-number
         part="percent"
         .value=${value}
         type="percent"
+        .min=${min}
+        .max=${max}
         @change=${onChange}
     ></cc-draggable-number>
     <span>%</span>

--- a/src/components/rotation-property-input/index.spec.ts
+++ b/src/components/rotation-property-input/index.spec.ts
@@ -41,4 +41,29 @@ describe('rotation-property-input', () => {
         await comp.updateComplete;
         expect(comp.value).toBe(2 * 360 + 45);
     });
+
+    it('forwards min and max to draggable numbers', async () => {
+        document.body.innerHTML = '<cc-rotation-property-input min="0" max="360"></cc-rotation-property-input>';
+        const comp = document.querySelector('cc-rotation-property-input') as HTMLElement & {
+            shadowRoot: ShadowRoot;
+            updateComplete: Promise<unknown>;
+        };
+        await comp.updateComplete;
+        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as HTMLElement & {
+            min: number | null;
+            max: number | null;
+            updateComplete: Promise<unknown>;
+        };
+        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as HTMLElement & {
+            min: number | null;
+            max: number | null;
+            updateComplete: Promise<unknown>;
+        };
+        await rotations.updateComplete;
+        await degrees.updateComplete;
+        expect(rotations.min).toBe(0);
+        expect(rotations.max).toBe(360);
+        expect(degrees.min).toBe(0);
+        expect(degrees.max).toBe(360);
+    });
 });

--- a/src/components/rotation-property-input/index.ts
+++ b/src/components/rotation-property-input/index.ts
@@ -10,15 +10,25 @@ export class RotationPropertyInput extends LitElement {
     static styles = css`${unsafeCSS(componentStyles)}`;
 
     static properties = {
-        value: { type: Number, reflect: true }
+        value: { type: Number, reflect: true },
+        min: { type: Number, reflect: true },
+        max: { type: Number, reflect: true }
     };
 
     declare value: number;
+    declare min: number | null;
+    declare max: number | null;
 
     constructor() {
         super();
         if (!this.hasAttribute('value')) {
             this.value = 0;
+        }
+        if (!this.hasAttribute('min')) {
+            this.min = null;
+        }
+        if (!this.hasAttribute('max')) {
+            this.max = null;
         }
     }
 
@@ -37,7 +47,9 @@ export class RotationPropertyInput extends LitElement {
     render() {
         return template(
             this.value,
-            this._onNumberChange.bind(this)
+            this._onNumberChange.bind(this),
+            this.min,
+            this.max
         );
     }
 }

--- a/src/components/rotation-property-input/template.ts
+++ b/src/components/rotation-property-input/template.ts
@@ -2,12 +2,16 @@ import { html } from 'lit';
 
 export const template = (
     value: number,
-    onChange: (e: Event) => void
+    onChange: (e: Event) => void,
+    min: number | null,
+    max: number | null
 ) => html`<cc-property-input .value=${value}>
     <cc-draggable-number
         part="rotations"
         .value=${value}
         type="whole-rotation"
+        .min=${min}
+        .max=${max}
         @change=${onChange}
     ></cc-draggable-number>
     <span>x</span>
@@ -15,6 +19,8 @@ export const template = (
         part="degrees"
         .value=${value}
         type="part-rotation"
+        .min=${min}
+        .max=${max}
         @change=${onChange}
     ></cc-draggable-number>
     <span>°</span>


### PR DESCRIPTION
## Summary
- support `min` and `max` attributes in `cc-draggable-number`
- forward those attributes from percent and rotation property inputs
- document the new behaviour
- test new features

## Testing
- `npm run lint`
- `npm test`
