### PR TITLE
Fix pointer lock delta handling

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -187,6 +187,22 @@ describe('DraggableNumber', () => {
         globalWithDoc.document = originalDoc;
     });
 
+    it('accumulates movement correctly when pointer is locked', () => {
+        const component = new DraggableNumber();
+        const target = {
+            setPointerCapture: vi.fn(),
+            requestPointerLock: vi.fn()
+        } as unknown as HTMLElement;
+        const globalWithDoc = globalThis as { document?: Document & { pointerLockElement?: Element } };
+        const originalDoc = globalWithDoc.document;
+        globalWithDoc.document = { pointerLockElement: target } as unknown as Document & { pointerLockElement?: Element };
+        component['_onPointerDown']({ target, clientX: 0, pointerId: 1 } as unknown as PointerEvent);
+        component['_onPointerMove']({ movementX: 3 } as unknown as PointerEvent);
+        component['_onPointerMove']({ movementX: 2 } as unknown as PointerEvent);
+        expect(component.value).toBe(5);
+        globalWithDoc.document = originalDoc;
+    });
+
     it('click does not start editing after a drag', () => {
         const component = new DraggableNumber();
         const target = { setPointerCapture: vi.fn() } as unknown as HTMLElement;

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -38,7 +38,6 @@ export class DraggableNumber extends LitElement {
     private _dragging = false;
     private _moved = false;
     private _prevX = 0;
-    private _lockDelta = 0;
 
     declare value: number;
     declare type: DraggableNumberType;
@@ -122,7 +121,6 @@ export class DraggableNumber extends LitElement {
         const target = e.target as HTMLElement;
         this._dragging = true;
         this._moved = false;
-        this._lockDelta = 0;
         this._prevX = e.clientX;
         target.setPointerCapture(e.pointerId);
         if (target.requestPointerLock) {
@@ -136,8 +134,7 @@ export class DraggableNumber extends LitElement {
         const hasLock =
             typeof document !== 'undefined' && document.pointerLockElement;
         if (hasLock) {
-            this._lockDelta += e.movementX;
-            delta = this._lockDelta;
+            delta = e.movementX;
         } else {
             delta = e.clientX - this._prevX;
         }
@@ -201,7 +198,6 @@ export class DraggableNumber extends LitElement {
     private _stopDrag(e: PointerEvent) {
         const target = e.target as HTMLElement;
         this._dragging = false;
-        this._lockDelta = 0;
         target.releasePointerCapture(e.pointerId);
         if (typeof document !== 'undefined' && document.exitPointerLock) {
             document.exitPointerLock();


### PR DESCRIPTION
## Summary
- prevent delta accumulation when pointer is locked in draggable-number
- add regression test for locked-pointer movement

## Testing
- `npm run lint`
- `npm test`
