### PR TITLE
Add disabled support across inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ value is formatted and interpreted:
 Optional `min` and `max` attributes can constrain the value. When omitted,
 no bounds are applied.
 
+All input components also support a `disabled` attribute that prevents
+interaction and mirrors the semantics of native form controls.
+
 The overlay input used when editing is absolutely positioned, so place
 `cc-draggable-number` inside a relatively positioned container to keep the
 overlay aligned.
@@ -91,7 +94,8 @@ overlay aligned.
 The value is shown in the format `Nx±D°`, where `N` is the number of full `360°` rotations
 and `D` is the remaining degrees. Internally it uses `cc-property-input` with two nested
 `cc-draggable-number` elements.
-`min` and `max` attributes are forwarded to both numbers.
+`min` and `max` attributes are forwarded to both numbers. The `disabled`
+attribute disables all nested inputs.
 
 ```html
 <cc-rotation-property-input value="390"></cc-rotation-property-input>
@@ -104,7 +108,8 @@ The example above renders the value as `1x+30°`.
 The component maps its internal value from the range `0`–`1` to display
 `0`–`100` without clamping. Internally it uses `cc-property-input` with a
 single `cc-draggable-number` element configured with `type="percent"`.
-`min` and `max` attributes are passed through to that element.
+`min` and `max` attributes are passed through to that element. The `disabled`
+attribute disables the input.
 
 ```html
 <cc-percent-property-input value="0.35"></cc-percent-property-input>

--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -366,4 +366,17 @@ describe('draggable-number DOM', () => {
         const newSpan = comp.shadowRoot.querySelector('span') as HTMLElement;
         expect(comp.shadowRoot.activeElement).not.toBe(newSpan);
     });
+
+    it('ignores interaction when disabled', () => {
+        const component = new DraggableNumber();
+        component.disabled = true;
+        component.value = 0;
+
+        component['_onClick']();
+        expect(component.editing).toBe(false);
+
+        const keyEvent = { key: 'ArrowUp' } as KeyboardEvent;
+        component['_onKeyDown'](keyEvent);
+        expect(component.value).toBe(0);
+    });
 });

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -34,7 +34,8 @@ export class DraggableNumber extends LitElement {
         type: { type: String },
         min: { type: Number, reflect: true },
         max: { type: Number, reflect: true },
-        step: { type: Number, reflect: true }
+        step: { type: Number, reflect: true },
+        disabled: { type: Boolean, reflect: true }
     } as const;
 
     private _dragging = false;
@@ -46,6 +47,7 @@ export class DraggableNumber extends LitElement {
     declare min: number | null;
     declare max: number | null;
     declare step: number;
+    declare disabled: boolean;
 
     constructor() {
         super();
@@ -60,6 +62,9 @@ export class DraggableNumber extends LitElement {
         }
         if (!this.hasAttribute('max')) {
             this.max = null;
+        }
+        if (!this.hasAttribute('disabled')) {
+            this.disabled = false;
         }
     }
 
@@ -94,6 +99,9 @@ export class DraggableNumber extends LitElement {
                 this._focusDisplayNext = false;
             }
         }
+        if (changed.has('disabled') && this.disabled && this.editing) {
+            this._setEditing(false);
+        }
     }
 
     render() {
@@ -108,11 +116,16 @@ export class DraggableNumber extends LitElement {
             this._onClick.bind(this),
             this.min,
             this.max,
-            this.step
+            this.step,
+            this.disabled
         );
     }
 
     private _onBlur(e: Event) {
+        if (this.disabled) {
+            this._setEditing(false);
+            return;
+        }
         const input = e.target as HTMLInputElement;
         const raw = parseFloat(input.value);
         if (!isNaN(raw)) {
@@ -123,6 +136,7 @@ export class DraggableNumber extends LitElement {
     }
 
     private _onPointerDown(e: PointerEvent) {
+        if (this.disabled) return;
         const target = e.target as HTMLElement;
         this._dragging = true;
         this._moved = false;
@@ -134,7 +148,7 @@ export class DraggableNumber extends LitElement {
     }
 
     private _onPointerMove(e: PointerEvent) {
-        if (!this._dragging) return;
+        if (!this._dragging || this.disabled) return;
         let delta: number;
         const hasLock =
             typeof document !== 'undefined' && document.pointerLockElement;
@@ -207,6 +221,7 @@ export class DraggableNumber extends LitElement {
     }
 
     private _stopDrag(e: PointerEvent) {
+        if (this.disabled) return;
         const target = e.target as HTMLElement;
         this._dragging = false;
         target.releasePointerCapture(e.pointerId);
@@ -216,6 +231,7 @@ export class DraggableNumber extends LitElement {
     }
 
     private _onClick() {
+        if (this.disabled) return;
         if (!this._moved) {
             this._setEditing(true);
         }
@@ -223,6 +239,7 @@ export class DraggableNumber extends LitElement {
     }
 
     private _onKeyDown(e: KeyboardEvent) {
+        if (this.disabled) return;
         if (this.editing) {
             if (e.key === 'Enter') {
                 const input = e.target as HTMLInputElement;

--- a/src/components/draggable-number/template.ts
+++ b/src/components/draggable-number/template.ts
@@ -11,10 +11,12 @@ export const template = (
     onClick: () => void,
     min: number | null,
     max: number | null,
-    step: number | null
+    step: number | null,
+    disabled: boolean
 ) => html`
     <span
-        tabindex="0"
+        tabindex="${disabled ? -1 : 0}"
+        aria-disabled="${disabled ? 'true' : 'false'}"
         @click=${onClick}
         @keydown=${onKeyDown}
         @pointerdown=${onPointerDown}
@@ -30,6 +32,7 @@ export const template = (
               .min=${min === null ? '' : String(min)}
               .max=${max === null ? '' : String(max)}
               .step=${step === null ? '' : String(step)}
+              ?disabled=${disabled}
               @blur=${onBlur}
               @keydown=${onKeyDown}
           />`

--- a/src/components/percent-property-input/index.spec.ts
+++ b/src/components/percent-property-input/index.spec.ts
@@ -45,4 +45,16 @@ describe('percent-property-input', () => {
         expect(percent.min).toBe(0);
         expect(percent.max).toBe(1);
     });
+
+    it('forwards disabled to the draggable number', async () => {
+        document.body.innerHTML = '<cc-percent-property-input disabled></cc-percent-property-input>';
+        const comp = document.querySelector('cc-percent-property-input') as HTMLElement & {
+            shadowRoot: ShadowRoot;
+            updateComplete: Promise<unknown>;
+        };
+        await comp.updateComplete;
+        const percent = comp.shadowRoot.querySelector('[part=percent]') as HTMLElement & { disabled: boolean; updateComplete: Promise<unknown> };
+        await percent.updateComplete;
+        expect(percent.disabled).toBe(true);
+    });
 });

--- a/src/components/percent-property-input/index.ts
+++ b/src/components/percent-property-input/index.ts
@@ -12,12 +12,14 @@ export class PercentPropertyInput extends LitElement {
     static properties = {
         value: { type: Number, reflect: true },
         min: { type: Number, reflect: true },
-        max: { type: Number, reflect: true }
+        max: { type: Number, reflect: true },
+        disabled: { type: Boolean, reflect: true }
     };
 
     declare value: number;
     declare min: number | null;
     declare max: number | null;
+    declare disabled: boolean;
 
     constructor() {
         super();
@@ -29,6 +31,9 @@ export class PercentPropertyInput extends LitElement {
         }
         if (!this.hasAttribute('max')) {
             this.max = null;
+        }
+        if (!this.hasAttribute('disabled')) {
+            this.disabled = false;
         }
     }
 
@@ -49,7 +54,8 @@ export class PercentPropertyInput extends LitElement {
             this.value,
             this._onNumberChange.bind(this),
             this.min,
-            this.max
+            this.max,
+            this.disabled
         );
     }
 }

--- a/src/components/percent-property-input/template.ts
+++ b/src/components/percent-property-input/template.ts
@@ -4,14 +4,16 @@ export const template = (
     value: number,
     onChange: (e: Event) => void,
     min: number | null,
-    max: number | null
-) => html`<cc-property-input .value=${value}>
+    max: number | null,
+    disabled: boolean
+) => html`<cc-property-input .value=${value} ?disabled=${disabled}>
     <cc-draggable-number
         part="percent"
         .value=${value}
         type="percent"
         .min=${min}
         .max=${max}
+        ?disabled=${disabled}
         @change=${onChange}
     ></cc-draggable-number>
     <span>%</span>

--- a/src/components/property-input/index.spec.ts
+++ b/src/components/property-input/index.spec.ts
@@ -101,4 +101,17 @@ describe('property-input', () => {
         expect(changeCount).toBe(1);
         expect(child.value).toBe(2);
     });
+
+    it('forwards disabled state to children', async () => {
+        document.body.innerHTML = `
+            <cc-property-input disabled>
+                <cc-draggable-number></cc-draggable-number>
+            </cc-property-input>
+        `;
+
+        const container = document.querySelector('cc-property-input') as HTMLElement & { updateComplete: Promise<unknown> };
+        await container.updateComplete;
+        const child = container.querySelector('cc-draggable-number') as HTMLElement & { disabled: boolean };
+        expect(child.disabled).toBe(true);
+    });
 });

--- a/src/components/property-input/index.ts
+++ b/src/components/property-input/index.ts
@@ -8,15 +8,20 @@ export class PropertyInput extends LitElement {
     static styles = css`${unsafeCSS(componentStyles)}`;
 
     static properties = {
-        value: { type: Number, reflect: true }
+        value: { type: Number, reflect: true },
+        disabled: { type: Boolean, reflect: true }
     };
 
     declare value: number;
+    declare disabled: boolean;
 
     constructor() {
         super();
         if (!this.hasAttribute('value')) {
             this.value = 0;
+        }
+        if (!this.hasAttribute('disabled')) {
+            this.disabled = false;
         }
     }
 
@@ -32,9 +37,9 @@ export class PropertyInput extends LitElement {
     }
 
     updated(changed: Map<string, unknown>) {
-        if (changed.has('value')) {
+        if (changed.has('value') || changed.has('disabled')) {
             this._updateChildren();
-            if (changed.get('value') !== undefined) {
+            if (changed.has('value') && changed.get('value') !== undefined) {
                 this.dispatchEvent(new Event('change'));
             }
         }
@@ -52,6 +57,7 @@ export class PropertyInput extends LitElement {
             num.addEventListener('change', handler as EventListener);
             this._listeners.set(num, handler);
             num.value = this.value;
+            (num as unknown as { disabled?: boolean }).disabled = this.disabled;
         });
         this._listeners.forEach((handler, num) => {
             if (!num.isConnected || !this.contains(num)) {
@@ -75,6 +81,7 @@ export class PropertyInput extends LitElement {
             if (num.value !== this.value) {
                 num.value = this.value;
             }
+            (num as unknown as { disabled?: boolean }).disabled = this.disabled;
         });
     }
 }

--- a/src/components/rotation-property-input/index.spec.ts
+++ b/src/components/rotation-property-input/index.spec.ts
@@ -66,4 +66,19 @@ describe('rotation-property-input', () => {
         expect(degrees.min).toBe(0);
         expect(degrees.max).toBe(360);
     });
+
+    it('forwards disabled to draggable numbers', async () => {
+        document.body.innerHTML = '<cc-rotation-property-input disabled></cc-rotation-property-input>';
+        const comp = document.querySelector('cc-rotation-property-input') as HTMLElement & {
+            shadowRoot: ShadowRoot;
+            updateComplete: Promise<unknown>;
+        };
+        await comp.updateComplete;
+        const rotations = comp.shadowRoot.querySelector('[part=rotations]') as HTMLElement & { disabled: boolean; updateComplete: Promise<unknown> };
+        const degrees = comp.shadowRoot.querySelector('[part=degrees]') as HTMLElement & { disabled: boolean; updateComplete: Promise<unknown> };
+        await rotations.updateComplete;
+        await degrees.updateComplete;
+        expect(rotations.disabled).toBe(true);
+        expect(degrees.disabled).toBe(true);
+    });
 });

--- a/src/components/rotation-property-input/index.ts
+++ b/src/components/rotation-property-input/index.ts
@@ -12,12 +12,14 @@ export class RotationPropertyInput extends LitElement {
     static properties = {
         value: { type: Number, reflect: true },
         min: { type: Number, reflect: true },
-        max: { type: Number, reflect: true }
+        max: { type: Number, reflect: true },
+        disabled: { type: Boolean, reflect: true }
     };
 
     declare value: number;
     declare min: number | null;
     declare max: number | null;
+    declare disabled: boolean;
 
     constructor() {
         super();
@@ -29,6 +31,9 @@ export class RotationPropertyInput extends LitElement {
         }
         if (!this.hasAttribute('max')) {
             this.max = null;
+        }
+        if (!this.hasAttribute('disabled')) {
+            this.disabled = false;
         }
     }
 
@@ -49,7 +54,8 @@ export class RotationPropertyInput extends LitElement {
             this.value,
             this._onNumberChange.bind(this),
             this.min,
-            this.max
+            this.max,
+            this.disabled
         );
     }
 }

--- a/src/components/rotation-property-input/template.ts
+++ b/src/components/rotation-property-input/template.ts
@@ -4,14 +4,16 @@ export const template = (
     value: number,
     onChange: (e: Event) => void,
     min: number | null,
-    max: number | null
-) => html`<cc-property-input .value=${value}>
+    max: number | null,
+    disabled: boolean
+) => html`<cc-property-input .value=${value} ?disabled=${disabled}>
     <cc-draggable-number
         part="rotations"
         .value=${value}
         type="whole-rotation"
         .min=${min}
         .max=${max}
+        ?disabled=${disabled}
         @change=${onChange}
     ></cc-draggable-number>
     <span>x</span>
@@ -21,6 +23,7 @@ export const template = (
         type="part-rotation"
         .min=${min}
         .max=${max}
+        ?disabled=${disabled}
         @change=${onChange}
     ></cc-draggable-number>
     <span>°</span>


### PR DESCRIPTION
## Summary
- add `disabled` attribute to input components
- disable interactions when the property is set
- forward `disabled` through property wrappers
- document the new attribute
- test disabled behaviour

## Testing
- `npm run lint`
- `npm run test`
