### PR TITLE
Release pointer lock on disable

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -35,6 +35,29 @@ describe('DraggableNumber', () => {
         globalWithDoc.document = originalDocument;
     });
 
+    it('releases pointer lock when disabled during drag', () => {
+        const component = new DraggableNumber();
+        const input = {
+            setPointerCapture: vi.fn(),
+            releasePointerCapture: vi.fn(),
+            requestPointerLock: vi.fn()
+        } as unknown as HTMLInputElement;
+
+        const exitLock = vi.fn();
+        const globalWithDoc = globalThis as { document?: Document };
+        const originalDocument = globalWithDoc.document;
+        globalWithDoc.document = { exitPointerLock: exitLock } as unknown as Document;
+
+        component['_onPointerDown']({ target: input, clientX: 0, pointerId: 1 } as unknown as PointerEvent);
+        component.disabled = true;
+        component.updated(new Map([['disabled', false]]));
+
+        expect(exitLock).toHaveBeenCalled();
+        expect((component as unknown as { _dragging: boolean })._dragging).toBe(false);
+
+        globalWithDoc.document = originalDocument;
+    });
+
     it('adjusts value with arrow keys', () => {
         const component = new DraggableNumber();
         component.value = 0;

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -99,8 +99,18 @@ export class DraggableNumber extends LitElement {
                 this._focusDisplayNext = false;
             }
         }
-        if (changed.has('disabled') && this.disabled && this.editing) {
-            this._setEditing(false);
+        if (changed.has('disabled') && this.disabled) {
+            if (this.editing) {
+                this._setEditing(false);
+            }
+            if (
+                typeof document !== 'undefined' &&
+                typeof (document as Document & { exitPointerLock?: () => void }).exitPointerLock ===
+                    'function'
+            ) {
+                (document as Document & { exitPointerLock?: () => void }).exitPointerLock();
+            }
+            this._dragging = false;
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure draggable-number exits pointer lock when disabled
- test releasing pointer lock when disabled during drag

## Testing
- `npm run lint`
- `npm run test`
