### PR TITLE
Remove wasm build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build:wasm": "cargo build --target wasm32-unknown-unknown --manifest-path Cargo.toml",
         "typecheck": "tsc --noEmit",
-        "build": "npm run typecheck && npm run build:wasm && vite build",
-        "lint": "npm run typecheck && eslint --ext .ts src && cargo fmt -- --check && cargo clippy -- -D warnings",
+        "build": "npm run typecheck && vite build",
+        "lint": "npm run typecheck && eslint --ext .ts src",
         "test": "npm run typecheck && vitest run"
     },
     "devDependencies": {


### PR DESCRIPTION
## Summary
- delete the `build:wasm` script from `package.json`
- simplify the `build` and `lint` scripts

## Testing
- `npm run lint`
- `npm run test`