### PR TITLE
Refactor numeric property inputs

### DIFF
--- a/src/components/base-numeric-property-input/index.ts
+++ b/src/components/base-numeric-property-input/index.ts
@@ -1,0 +1,57 @@
+import { LitElement, css, unsafeCSS } from 'lit';
+import componentStyles from './style.css?inline';
+import { defineDraggableNumber } from '../draggable-number';
+import { definePropertyInput } from '../property-input';
+
+// Shared DraggableNumber element interface
+export type DraggableNumberElement = HTMLElement & { value: number };
+
+export class BaseNumericPropertyInput extends LitElement {
+    static styles = css`${unsafeCSS(componentStyles)}`;
+
+    static properties = {
+        value: { type: Number, reflect: true },
+        min: { type: Number, reflect: true },
+        max: { type: Number, reflect: true },
+        disabled: { type: Boolean, reflect: true }
+    } as const;
+
+    declare value: number;
+    declare min: number | null;
+    declare max: number | null;
+    declare disabled: boolean;
+
+    constructor() {
+        super();
+        if (!this.hasAttribute('value')) {
+            this.value = 0;
+        }
+        if (!this.hasAttribute('min')) {
+            this.min = null;
+        }
+        if (!this.hasAttribute('max')) {
+            this.max = null;
+        }
+        if (!this.hasAttribute('disabled')) {
+            this.disabled = false;
+        }
+    }
+
+    protected _onNumberChange(e: Event) {
+        const val = (e.target as DraggableNumberElement).value;
+        this.value = val;
+        this.dispatchEvent(new Event('change'));
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        definePropertyInput();
+        defineDraggableNumber();
+    }
+}
+
+export function defineBaseNumericPropertyInput() {
+    if (!customElements.get('cc-base-numeric-property-input')) {
+        customElements.define('cc-base-numeric-property-input', BaseNumericPropertyInput);
+    }
+}

--- a/src/components/base-numeric-property-input/style.css
+++ b/src/components/base-numeric-property-input/style.css
@@ -1,0 +1,3 @@
+:host {
+    display: inline-block;
+}

--- a/src/components/percent-property-input/index.ts
+++ b/src/components/percent-property-input/index.ts
@@ -1,53 +1,10 @@
-import { LitElement, css, unsafeCSS } from 'lit';
+import { css, unsafeCSS } from 'lit';
 import componentStyles from './style.css?inline';
 import { template } from './template';
-import { defineDraggableNumber } from '../draggable-number';
-import { definePropertyInput } from '../property-input';
+import { BaseNumericPropertyInput } from '../base-numeric-property-input';
 
-type DraggableNumberElement = HTMLElement & { value: number };
-
-export class PercentPropertyInput extends LitElement {
+export class PercentPropertyInput extends BaseNumericPropertyInput {
     static styles = css`${unsafeCSS(componentStyles)}`;
-
-    static properties = {
-        value: { type: Number, reflect: true },
-        min: { type: Number, reflect: true },
-        max: { type: Number, reflect: true },
-        disabled: { type: Boolean, reflect: true }
-    };
-
-    declare value: number;
-    declare min: number | null;
-    declare max: number | null;
-    declare disabled: boolean;
-
-    constructor() {
-        super();
-        if (!this.hasAttribute('value')) {
-            this.value = 0;
-        }
-        if (!this.hasAttribute('min')) {
-            this.min = null;
-        }
-        if (!this.hasAttribute('max')) {
-            this.max = null;
-        }
-        if (!this.hasAttribute('disabled')) {
-            this.disabled = false;
-        }
-    }
-
-    private _onNumberChange(e: Event) {
-        const val = (e.target as DraggableNumberElement).value;
-        this.value = val;
-        this.dispatchEvent(new Event('change'));
-    }
-
-    connectedCallback() {
-        super.connectedCallback();
-        definePropertyInput();
-        defineDraggableNumber();
-    }
 
     render() {
         return template(

--- a/src/components/rotation-property-input/index.ts
+++ b/src/components/rotation-property-input/index.ts
@@ -1,53 +1,10 @@
-import { LitElement, css, unsafeCSS } from 'lit';
+import { css, unsafeCSS } from 'lit';
 import componentStyles from './style.css?inline';
 import { template } from './template';
-import { defineDraggableNumber } from '../draggable-number';
-import { definePropertyInput } from '../property-input';
+import { BaseNumericPropertyInput } from '../base-numeric-property-input';
 
-type DraggableNumberElement = HTMLElement & { value: number };
-
-export class RotationPropertyInput extends LitElement {
+export class RotationPropertyInput extends BaseNumericPropertyInput {
     static styles = css`${unsafeCSS(componentStyles)}`;
-
-    static properties = {
-        value: { type: Number, reflect: true },
-        min: { type: Number, reflect: true },
-        max: { type: Number, reflect: true },
-        disabled: { type: Boolean, reflect: true }
-    };
-
-    declare value: number;
-    declare min: number | null;
-    declare max: number | null;
-    declare disabled: boolean;
-
-    constructor() {
-        super();
-        if (!this.hasAttribute('value')) {
-            this.value = 0;
-        }
-        if (!this.hasAttribute('min')) {
-            this.min = null;
-        }
-        if (!this.hasAttribute('max')) {
-            this.max = null;
-        }
-        if (!this.hasAttribute('disabled')) {
-            this.disabled = false;
-        }
-    }
-
-    private _onNumberChange(e: Event) {
-        const val = (e.target as DraggableNumberElement).value;
-        this.value = val;
-        this.dispatchEvent(new Event('change'));
-    }
-
-    connectedCallback() {
-        super.connectedCallback();
-        definePropertyInput();
-        defineDraggableNumber();
-    }
 
     render() {
         return template(


### PR DESCRIPTION
## Summary
- add `BaseNumericPropertyInput` class
- use the base class for percent and rotation property inputs

## Testing
- `npm run lint`
- `npm test`
