### PR TITLE
Remove rust toolchain step from lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,10 +13,5 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rustfmt, clippy
       - run: npm install
       - run: npm run lint


### PR DESCRIPTION
## Summary
- remove unnecessary `actions-rs/toolchain` step from the lint workflow

## Testing
- `npm run lint`
- `npm test`
