### PR TITLE
Add spinbutton aria attributes

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -304,6 +304,16 @@ describe('draggable-number DOM', () => {
         const span = comp.shadowRoot.querySelector('span');
         expect(span?.getAttribute('tabindex')).toBe('0');
     });
+    it('exposes spinbutton aria attributes', async () => {
+        document.body.innerHTML = '<cc-draggable-number value="3" min="1" max="5"></cc-draggable-number>';
+        const comp = document.querySelector('cc-draggable-number') as HTMLElement & { shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };
+        await comp.updateComplete;
+        const span = comp.shadowRoot.querySelector('span') as HTMLElement;
+        expect(span.getAttribute('role')).toBe('spinbutton');
+        expect(span.getAttribute('aria-valuenow')).toBe('3');
+        expect(span.getAttribute('aria-valuemin')).toBe('1');
+        expect(span.getAttribute('aria-valuemax')).toBe('5');
+    });
     it('shows input after click', async () => {
         document.body.innerHTML = '<cc-draggable-number></cc-draggable-number>';
         const comp = document.querySelector('cc-draggable-number') as HTMLElement & { shadowRoot: ShadowRoot; updateComplete: Promise<unknown> };

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -120,6 +120,7 @@ export class DraggableNumber extends LitElement {
     render() {
         return template(
             this._formatValue(),
+            this.value,
             this.editing,
             this._onBlur.bind(this),
             this._onKeyDown.bind(this),

--- a/src/components/draggable-number/template.ts
+++ b/src/components/draggable-number/template.ts
@@ -1,7 +1,9 @@
 import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 export const template = (
     value: string | number,
+    valueNow: number,
     editing: boolean,
     onBlur: (e: Event) => void,
     onKeyDown: (e: KeyboardEvent) => void,
@@ -15,8 +17,12 @@ export const template = (
     disabled: boolean
 ) => html`
     <span
+        role="spinbutton"
         tabindex="${disabled ? -1 : 0}"
         aria-disabled="${disabled ? 'true' : 'false'}"
+        aria-valuenow="${valueNow}"
+        aria-valuemin="${ifDefined(min === null ? undefined : min)}"
+        aria-valuemax="${ifDefined(max === null ? undefined : max)}"
         @click=${onClick}
         @keydown=${onKeyDown}
         @pointerdown=${onPointerDown}


### PR DESCRIPTION
## Summary
- expose spinbutton semantics in `cc-draggable-number`
- test that ARIA attributes appear on span

## Testing
- `npm run lint`
- `npm test`
