### PR TITLE
Add dragFactor sensitivity to draggable-number

### DIFF
--- a/src/components/draggable-number/index.spec.ts
+++ b/src/components/draggable-number/index.spec.ts
@@ -197,6 +197,15 @@ describe('DraggableNumber', () => {
         expect(component.value).toBeCloseTo(0.01);
     });
 
+    it('applies dragFactor to drag change', () => {
+        const component = new DraggableNumber();
+        component.dragFactor = 0.5;
+        const target = { setPointerCapture: vi.fn() } as unknown as HTMLElement;
+        component['_onPointerDown']({ target, clientX: 0, pointerId: 1 } as unknown as PointerEvent);
+        component['_onPointerMove']({ clientX: 2 } as unknown as PointerEvent);
+        expect(component.value).toBe(1);
+    });
+
     it('formats and parses percent type', () => {
         const component = new DraggableNumber();
         component.type = 'percent';

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -38,7 +38,8 @@ export class DraggableNumber extends LitElement {
         min: { type: Number, reflect: true },
         max: { type: Number, reflect: true },
         step: { type: Number, reflect: true },
-        disabled: { type: Boolean, reflect: true }
+        disabled: { type: Boolean, reflect: true },
+        dragFactor: { type: Number, reflect: true }
     } as const;
 
     private _dragging = false;
@@ -51,6 +52,7 @@ export class DraggableNumber extends LitElement {
     declare max: number | null;
     declare step: number;
     declare disabled: boolean;
+    declare dragFactor: number;
 
     constructor() {
         super();
@@ -68,6 +70,9 @@ export class DraggableNumber extends LitElement {
         }
         if (!this.hasAttribute('disabled')) {
             this.disabled = false;
+        }
+        if (!this.hasAttribute('dragFactor')) {
+            this.dragFactor = 1;
         }
     }
 
@@ -173,7 +178,7 @@ export class DraggableNumber extends LitElement {
         }
 
         if (delta !== 0) this._moved = true;
-        let change = process_drag(delta);
+        let change = process_drag(delta) * this.dragFactor;
         if (this.type === 'whole-rotation') {
             change *= 360;
         }


### PR DESCRIPTION
## Summary
- allow adjusting drag sensitivity via a new `dragFactor` property
- apply `dragFactor` in the drag handler
- test custom drag sensitivity

## Testing
- `npm run lint`
- `npm test`
