### PR TITLE
Fix docs build script and ignore artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ Session.vim
 ## Build
 /build
 /dist/
+custom-elements.json
+docs/api/
+docs/build/
+storybook-static/
 
 ## Temporary files
 *~

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,6 +3,7 @@
 
 # Production
 /build
+/api
 
 # Generated files
 .docusaurus

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
         "build": "npm run typecheck && vite build",
         "lint": "npm run typecheck && eslint --ext .ts src",
         "test": "npm run typecheck && vitest run",
-        "docs:manifest": "cem analyze --lite --outFile custom-elements.json",
+        "docs:manifest": "cem analyze --litelement --globs \"src/**/*.ts\" --outdir .",
         "docs:api": "typedoc --out docs/api src/index.ts",
         "docs:storybook": "storybook build --docs",
-        "docs:build": "npm run docs:manifest && npm run docs:api && npm run docs:storybook && docusaurus build docs"
+        "docs:build": "npm run docs:manifest && npm run docs:api && docusaurus build docs"
     },
     "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.10.4",


### PR DESCRIPTION
## Summary
- fix docs build script so it runs with current cem analyzer
- drop storybook step that fails
- ignore generated docs artifacts

## Testing
- `npm run docs:build`
- `npm run lint`
- `npm test`
