### PR TITLE
Add helper for custom element registration

### DIFF
--- a/src/components/base-numeric-property-input/index.ts
+++ b/src/components/base-numeric-property-input/index.ts
@@ -2,6 +2,7 @@ import { LitElement, css, unsafeCSS } from 'lit';
 import componentStyles from './style.css?inline';
 import { defineDraggableNumber } from '../draggable-number';
 import { definePropertyInput } from '../property-input';
+import { registerElement } from '../../register';
 
 // Shared DraggableNumber element interface
 export type DraggableNumberElement = HTMLElement & { value: number };
@@ -51,7 +52,5 @@ export class BaseNumericPropertyInput extends LitElement {
 }
 
 export function defineBaseNumericPropertyInput() {
-    if (!customElements.get('cc-base-numeric-property-input')) {
-        customElements.define('cc-base-numeric-property-input', BaseNumericPropertyInput);
-    }
+    registerElement('cc-base-numeric-property-input', BaseNumericPropertyInput);
 }

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, unsafeCSS } from 'lit';
 import componentStyles from './style.css?inline';
 import { template } from './template';
+import { registerElement } from '../../register';
 
 function processDrag(delta: number): number {
     return delta;
@@ -302,7 +303,5 @@ export class DraggableNumber extends LitElement {
 }
 
 export function defineDraggableNumber() {
-    if (!customElements.get('cc-draggable-number')) {
-        customElements.define('cc-draggable-number', DraggableNumber);
-    }
+    registerElement('cc-draggable-number', DraggableNumber);
 }

--- a/src/components/percent-property-input/index.ts
+++ b/src/components/percent-property-input/index.ts
@@ -2,6 +2,7 @@ import { css, unsafeCSS } from 'lit';
 import componentStyles from './style.css?inline';
 import { template } from './template';
 import { BaseNumericPropertyInput } from '../base-numeric-property-input';
+import { registerElement } from '../../register';
 
 export class PercentPropertyInput extends BaseNumericPropertyInput {
     static styles = css`${unsafeCSS(componentStyles)}`;
@@ -18,7 +19,5 @@ export class PercentPropertyInput extends BaseNumericPropertyInput {
 }
 
 export function definePercentPropertyInput() {
-    if (!customElements.get('cc-percent-property-input')) {
-        customElements.define('cc-percent-property-input', PercentPropertyInput);
-    }
+    registerElement('cc-percent-property-input', PercentPropertyInput);
 }

--- a/src/components/property-input/index.ts
+++ b/src/components/property-input/index.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, unsafeCSS } from 'lit';
 import componentStyles from './style.css?inline';
 import { template } from './template';
+import { registerElement } from '../../register';
 
 type DraggableNumberElement = HTMLElement & { value: number };
 
@@ -87,7 +88,5 @@ export class PropertyInput extends LitElement {
 }
 
 export function definePropertyInput() {
-    if (!customElements.get('cc-property-input')) {
-        customElements.define('cc-property-input', PropertyInput);
-    }
+    registerElement('cc-property-input', PropertyInput);
 }

--- a/src/components/rotation-property-input/index.ts
+++ b/src/components/rotation-property-input/index.ts
@@ -2,6 +2,7 @@ import { css, unsafeCSS } from 'lit';
 import componentStyles from './style.css?inline';
 import { template } from './template';
 import { BaseNumericPropertyInput } from '../base-numeric-property-input';
+import { registerElement } from '../../register';
 
 export class RotationPropertyInput extends BaseNumericPropertyInput {
     static styles = css`${unsafeCSS(componentStyles)}`;
@@ -18,7 +19,5 @@ export class RotationPropertyInput extends BaseNumericPropertyInput {
 }
 
 export function defineRotationPropertyInput() {
-    if (!customElements.get('cc-rotation-property-input')) {
-        customElements.define('cc-rotation-property-input', RotationPropertyInput);
-    }
+    registerElement('cc-rotation-property-input', RotationPropertyInput);
 }

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,0 +1,5 @@
+export function registerElement(tag: string, ctor: CustomElementConstructor): void {
+    if (!customElements.get(tag)) {
+        customElements.define(tag, ctor);
+    }
+}


### PR DESCRIPTION
## Summary
- add `registerElement` helper
- use `registerElement` in custom element registration
- stop exporting helper in public entry

## Testing
- `npm run lint`
- `npm test`
