### PR TITLE
refactor event delegation for property-input

### DIFF
--- a/src/components/base-numeric-property-input/index.spec.ts
+++ b/src/components/base-numeric-property-input/index.spec.ts
@@ -45,7 +45,7 @@ describe('base-numeric-property-input', () => {
             updateComplete: Promise<unknown>;
         };
         num.value = 8;
-        num.dispatchEvent(new Event('change'));
+        num.dispatchEvent(new Event('change', { bubbles: true }));
         await comp.updateComplete;
         expect(comp.value).toBe(8);
     });

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -148,7 +148,7 @@ export class DraggableNumber extends LitElement {
         const raw = parseFloat(input.value);
         if (!isNaN(raw)) {
             this.value = this._applyBounds(this._parseValue(raw));
-            this.dispatchEvent(new Event('change'));
+            this.dispatchEvent(new Event('change', { bubbles: true }));
         }
         this._setEditing(false);
     };
@@ -196,7 +196,7 @@ export class DraggableNumber extends LitElement {
         if (!hasLock) {
             this._prevX = e.clientX;
         }
-        this.dispatchEvent(new Event('change'));
+        this.dispatchEvent(new Event('change', { bubbles: true }));
     };
 
     private _formatValue(): string | number {
@@ -287,13 +287,13 @@ export class DraggableNumber extends LitElement {
         else if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
             const increment = this.step ?? (this.type === 'percent' ? 0.01 : 1);
             this.value = this._applyBounds(this.value + increment);
-            this.dispatchEvent(new Event('change'));
+            this.dispatchEvent(new Event('change', { bubbles: true }));
             e.preventDefault();
         }
         else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
             const increment = this.step ?? (this.type === 'percent' ? 0.01 : 1);
             this.value = this._applyBounds(this.value - increment);
-            this.dispatchEvent(new Event('change'));
+            this.dispatchEvent(new Event('change', { bubbles: true }));
             e.preventDefault();
         }
     };

--- a/src/components/percent-property-input/index.spec.ts
+++ b/src/components/percent-property-input/index.spec.ts
@@ -24,7 +24,7 @@ describe('percent-property-input', () => {
         await comp.updateComplete;
         const percent = comp.shadowRoot.querySelector('[part=percent]') as HTMLElement & { value: number; updateComplete: Promise<unknown> };
         percent.value = 0.45;
-        percent.dispatchEvent(new Event('change'));
+        percent.dispatchEvent(new Event('change', { bubbles: true }));
         await comp.updateComplete;
         expect(comp.value).toBeCloseTo(0.45);
     });

--- a/src/components/property-input/index.spec.ts
+++ b/src/components/property-input/index.spec.ts
@@ -27,7 +27,7 @@ describe('property-input', () => {
         container.addEventListener('change', () => changeCount++);
 
         first.value = 12;
-        first.dispatchEvent(new Event('change'));
+        first.dispatchEvent(new Event('change', { bubbles: true }));
         await container.updateComplete;
         await first.updateComplete;
         await second.updateComplete;
@@ -51,7 +51,7 @@ describe('property-input', () => {
         const second = document.createElement('cc-draggable-number') as HTMLElement & { value: number; updateComplete: Promise<unknown> };
         second.id = 'second';
         container.appendChild(second);
-        (container as unknown as { _onSlotChange: () => void })._onSlotChange();
+        await Promise.resolve();
         await second.updateComplete;
 
         expect(second.value).toBe(3);
@@ -61,7 +61,7 @@ describe('property-input', () => {
         container.addEventListener('change', onChange);
 
         second.value = 7;
-        second.dispatchEvent(new Event('change'));
+        second.dispatchEvent(new Event('change', { bubbles: true }));
         await container.updateComplete;
         await first.updateComplete;
         await second.updateComplete;
@@ -72,10 +72,10 @@ describe('property-input', () => {
 
         container.removeEventListener('change', onChange);
         second.remove();
-        (container as unknown as { _onSlotChange: () => void })._onSlotChange();
+        await Promise.resolve();
 
         second.value = 12;
-        second.dispatchEvent(new Event('change'));
+        second.dispatchEvent(new Event('change', { bubbles: true }));
         await container.updateComplete;
         expect(container.value).toBe(7);
     });

--- a/src/components/rotation-property-input/index.spec.ts
+++ b/src/components/rotation-property-input/index.spec.ts
@@ -32,12 +32,12 @@ describe('rotation-property-input', () => {
         await rotations.updateComplete;
         await degrees.updateComplete;
         rotations.value = 2 * 360 + 30;
-        rotations.dispatchEvent(new Event('change'));
+        rotations.dispatchEvent(new Event('change', { bubbles: true }));
         await comp.updateComplete;
         expect(comp.value).toBe(2 * 360 + 30);
 
         degrees.value = 2 * 360 + 45;
-        degrees.dispatchEvent(new Event('change'));
+        degrees.dispatchEvent(new Event('change', { bubbles: true }));
         await comp.updateComplete;
         expect(comp.value).toBe(2 * 360 + 45);
     });


### PR DESCRIPTION
## Summary
- handle child changes via event delegation on `<cc-property-input>`
- bubble `change` events from `<cc-draggable-number>`
- update specs for bubbling events

## Testing
- `npm test`
- `npm run lint`
