### PR TITLE
Use decorators for Lit properties

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,13 @@ export default [
             node: true
         },
         rules: {
-            indent: ['error', 4],
+            indent: [
+                'error',
+                4,
+                {
+                    ignoredNodes: ['PropertyDefinition[decorators]']
+                }
+            ],
             quotes: ['error', 'single'],
             'no-trailing-spaces': 'error',
             'eol-last': ['error', 'always'],

--- a/src/components/base-numeric-property-input/index.ts
+++ b/src/components/base-numeric-property-input/index.ts
@@ -1,4 +1,5 @@
 import { LitElement, css, unsafeCSS } from 'lit';
+import { property } from 'lit/decorators.js';
 import componentStyles from './style.css?inline';
 import { defineDraggableNumber } from '../draggable-number';
 import { definePropertyInput } from '../property-input';
@@ -9,33 +10,17 @@ export type DraggableNumberElement = HTMLElement & { value: number };
 export class BaseNumericPropertyInput extends LitElement {
     static styles = css`${unsafeCSS(componentStyles)}`;
 
-    static properties = {
-        value: { type: Number, reflect: true },
-        min: { type: Number, reflect: true },
-        max: { type: Number, reflect: true },
-        disabled: { type: Boolean, reflect: true }
-    } as const;
+    @property({ type: Number, reflect: true })
+    value = 0;
 
-    declare value: number;
-    declare min: number | null;
-    declare max: number | null;
-    declare disabled: boolean;
+    @property({ type: Number, reflect: true })
+    min: number | null = null;
 
-    constructor() {
-        super();
-        if (!this.hasAttribute('value')) {
-            this.value = 0;
-        }
-        if (!this.hasAttribute('min')) {
-            this.min = null;
-        }
-        if (!this.hasAttribute('max')) {
-            this.max = null;
-        }
-        if (!this.hasAttribute('disabled')) {
-            this.disabled = false;
-        }
-    }
+    @property({ type: Number, reflect: true })
+    max: number | null = null;
+
+    @property({ type: Boolean, reflect: true })
+    disabled = false;
 
     protected _onNumberChange(e: Event) {
         const val = (e.target as DraggableNumberElement).value;

--- a/src/components/draggable-number/index.ts
+++ b/src/components/draggable-number/index.ts
@@ -1,4 +1,5 @@
 import { LitElement, css, unsafeCSS } from 'lit';
+import { property } from 'lit/decorators.js';
 import componentStyles from './style.css?inline';
 import { template } from './template';
 
@@ -32,50 +33,32 @@ export class DraggableNumber extends LitElement {
         ${unsafeCSS(componentStyles)}
     `;
 
-    static properties = {
-        value: { type: Number, reflect: true },
-        type: { type: String },
-        min: { type: Number, reflect: true },
-        max: { type: Number, reflect: true },
-        step: { type: Number, reflect: true },
-        disabled: { type: Boolean, reflect: true },
-        dragFactor: { type: Number, attribute: 'drag-factor', reflect: true }
-    } as const;
+    @property({ type: Number, reflect: true })
+    value = 0;
+
+    @property({ type: String })
+    type: DraggableNumberType = 'raw';
+
+    @property({ type: Number, reflect: true })
+    min: number | null = null;
+
+    @property({ type: Number, reflect: true })
+    max: number | null = null;
+
+    @property({ type: Number, reflect: true })
+    step: number | null = null;
+
+    @property({ type: Boolean, reflect: true })
+    disabled = false;
+
+    @property({ type: Number, attribute: 'drag-factor', reflect: true })
+    dragFactor = 1;
 
     private _dragging = false;
     private _moved = false;
     private _prevX = 0;
     private _dragRemainder = 0;
 
-    declare value: number;
-    declare type: DraggableNumberType;
-    declare min: number | null;
-    declare max: number | null;
-    declare step: number;
-    declare disabled: boolean;
-    declare dragFactor: number;
-
-    constructor() {
-        super();
-        if (!this.hasAttribute('value')) {
-            this.value = 0;
-        }
-        if (!this.hasAttribute('type')) {
-            this.type = 'raw';
-        }
-        if (!this.hasAttribute('min')) {
-            this.min = null;
-        }
-        if (!this.hasAttribute('max')) {
-            this.max = null;
-        }
-        if (!this.hasAttribute('disabled')) {
-            this.disabled = false;
-        }
-        if (!this.hasAttribute('drag-factor')) {
-            this.dragFactor = 1;
-        }
-    }
 
     private _editing = false;
     private _focusDisplayNext = false;

--- a/src/components/property-input/index.ts
+++ b/src/components/property-input/index.ts
@@ -1,4 +1,5 @@
 import { LitElement, css, unsafeCSS } from 'lit';
+import { property } from 'lit/decorators.js';
 import componentStyles from './style.css?inline';
 import { template } from './template';
 
@@ -7,23 +8,11 @@ type DraggableNumberElement = HTMLElement & { value: number };
 export class PropertyInput extends LitElement {
     static styles = css`${unsafeCSS(componentStyles)}`;
 
-    static properties = {
-        value: { type: Number, reflect: true },
-        disabled: { type: Boolean, reflect: true }
-    };
+    @property({ type: Number, reflect: true })
+    value = 0;
 
-    declare value: number;
-    declare disabled: boolean;
-
-    constructor() {
-        super();
-        if (!this.hasAttribute('value')) {
-            this.value = 0;
-        }
-        if (!this.hasAttribute('disabled')) {
-            this.disabled = false;
-        }
-    }
+    @property({ type: Boolean, reflect: true })
+    disabled = false;
 
     private _listeners = new Map<DraggableNumberElement, EventListener>();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "outDir": "dist/types",
-        "types": ["vitest", "jsdom"]
+        "types": ["vitest", "jsdom"],
+        "experimentalDecorators": true,
+        "useDefineForClassFields": false
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- swap `static properties` for `@property` decorators
- set defaults on decorated fields
- allow decorators in the TypeScript config
- line up decorated fields with their decorators
- tweak indent rule to ignore decorated fields

## Testing
- `npm run lint`
- `npm test`
