### PR TITLE
Create side-effect-free entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,29 @@ npm run build
 Run `npm run test` to execute the test suite.
 Linting is performed using ESLint. Run `npm run lint` to check formatting and common issues.
 
+## Usage
+
+The package exposes two entrypoints:
+
+- `@leviathanbadger/cc-web-components` – side‑effect free. Import the components and call their `define*` methods yourself.
+
+  ```ts
+  import { DraggableNumber, defineDraggableNumber } from '@leviathanbadger/cc-web-components';
+
+  defineDraggableNumber();
+  const num = document.createElement('cc-draggable-number');
+  document.body.append(num);
+  ```
+
+- `@leviathanbadger/cc-web-components/define` – registers all components automatically as a side effect and only exports the component classes.
+
+  ```ts
+  import { DraggableNumber } from '@leviathanbadger/cc-web-components/define';
+
+  const num = document.createElement('cc-draggable-number');
+  document.body.append(num);
+  ```
+
 ## Draggable Number
 
 `<cc-draggable-number>` is an input that allows changing numerical values by

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
     "version": "0.1.0",
     "description": "Experimenting with Codex to create web components mimicking some of the controls in Adobe CC products.",
     "type": "module",
+    "main": "./dist/cc-web-components.umd.js",
+    "module": "./dist/cc-web-components.es.js",
+    "exports": {
+        ".": "./dist/cc-web-components.es.js",
+        "./define": "./dist/cc-web-components.define.es.js"
+    },
     "scripts": {
         "dev": "vite",
         "typecheck": "tsc --noEmit",

--- a/src/define.ts
+++ b/src/define.ts
@@ -1,0 +1,28 @@
+import {
+    defineDraggableNumber,
+    DraggableNumber,
+} from './components/draggable-number';
+import {
+    definePropertyInput,
+    PropertyInput,
+} from './components/property-input';
+import {
+    defineRotationPropertyInput,
+    RotationPropertyInput,
+} from './components/rotation-property-input';
+import {
+    definePercentPropertyInput,
+    PercentPropertyInput,
+} from './components/percent-property-input';
+
+defineDraggableNumber();
+definePropertyInput();
+defineRotationPropertyInput();
+definePercentPropertyInput();
+
+export {
+    DraggableNumber,
+    PropertyInput,
+    RotationPropertyInput,
+    PercentPropertyInput,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,3 @@
-import { defineDraggableNumber } from './components/draggable-number';
-import { definePropertyInput } from './components/property-input';
-import { defineRotationPropertyInput } from './components/rotation-property-input';
-import { definePercentPropertyInput } from './components/percent-property-input';
-
-defineDraggableNumber();
-definePropertyInput();
-defineRotationPropertyInput();
-definePercentPropertyInput();
-
 export * from './components/draggable-number';
 export * from './components/property-input';
 export * from './components/rotation-property-input';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,16 @@ import { resolve } from 'path';
 export default defineConfig({
     build: {
         lib: {
-            entry: resolve(__dirname, 'src/index.ts'),
+            entry: {
+                index: resolve(__dirname, 'src/index.ts'),
+                define: resolve(__dirname, 'src/define.ts')
+            },
             name: 'CCWebComponents',
             formats: ['es', 'umd'],
-            fileName: (format) => `cc-web-components.${format}.js`
+            fileName: (format, entryName) =>
+                entryName === 'index'
+                    ? `cc-web-components.${format}.js`
+                    : `cc-web-components.${entryName}.${format}.js`
         },
         rollupOptions: {
             external: [],


### PR DESCRIPTION
## Summary
- expose components without side effects
- add `define` convenience entry
- output both entrypoints from build
- document usage of both entrypoints

## Testing
- `npm run lint`
- `npm test`
