### PR TITLE
Remove draggable-number from exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,22 +71,22 @@ The package exposes two entrypoints:
 
 - `@leviathanbadger/cc-web-components` – side‑effect free. Import the components and call their `define*` methods yourself.
 
-  ```ts
-  import { DraggableNumber, defineDraggableNumber } from '@leviathanbadger/cc-web-components';
+```ts
+import { definePercentPropertyInput } from '@leviathanbadger/cc-web-components';
 
-  defineDraggableNumber();
-  const num = document.createElement('cc-draggable-number');
-  document.body.append(num);
-  ```
+definePercentPropertyInput();
+const percent = document.createElement('cc-percent-property-input');
+document.body.append(percent);
+```
 
 - `@leviathanbadger/cc-web-components/define` – registers all components automatically as a side effect and only exports the component classes.
 
-  ```ts
-  import { DraggableNumber } from '@leviathanbadger/cc-web-components/define';
+```ts
+import { PercentPropertyInput } from '@leviathanbadger/cc-web-components/define';
 
-  const num = document.createElement('cc-draggable-number');
-  document.body.append(num);
-  ```
+const percent = document.createElement('cc-percent-property-input');
+document.body.append(percent);
+```
 
 ## Draggable Number
 

--- a/src/define.ts
+++ b/src/define.ts
@@ -1,7 +1,4 @@
-import {
-    defineDraggableNumber,
-    DraggableNumber,
-} from './components/draggable-number';
+import { defineDraggableNumber } from './components/draggable-number';
 import {
     definePropertyInput,
     PropertyInput,
@@ -21,7 +18,6 @@ defineRotationPropertyInput();
 definePercentPropertyInput();
 
 export {
-    DraggableNumber,
     PropertyInput,
     RotationPropertyInput,
     PercentPropertyInput,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-export * from './components/draggable-number';
 export * from './components/property-input';
 export * from './components/rotation-property-input';
 export * from './components/percent-property-input';


### PR DESCRIPTION
## Summary
- drop draggable-number exports from library entrypoints
- adjust define module to keep registration but not export
- update usage docs with a different example

## Testing
- `npm run lint`
- `npm test`
