### PR TITLE
Fix npm publish auth via environment secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: master
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,9 @@ package-lock.json
 # Node modules (shouldn't be published)
 node_modules/
 
+# Documentation and configuration not needed in the package
+docs/
+.github/
+PROJECT-PLAN.md
+DOCUMENTATION.md
+

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "type": "module",
     "main": "./dist/cc-web-components.umd.js",
     "module": "./dist/cc-web-components.es.js",
+    "files": [
+        "dist",
+        "src/types.d.ts"
+    ],
     "exports": {
         ".": "./dist/cc-web-components.es.js",
         "./define": "./dist/cc-web-components.define.es.js"


### PR DESCRIPTION
## Summary
- reference the `master` environment in the publish workflow
- remove temporary npm auth step

## Testing
- `npm run lint`
- `npm test`
