### PR TITLE
Add stub docs and e2e test scaffolding

### DIFF
--- a/docs/docs/draggable-number.md
+++ b/docs/docs/draggable-number.md
@@ -1,0 +1,13 @@
+---
+sidebar_position: 1
+---
+
+# Draggable Number
+
+`<cc-draggable-number>` lets users change numeric values by clicking and dragging.
+
+```html
+<cc-draggable-number value="42"></cc-draggable-number>
+```
+
+A `change` event fires whenever the value updates.

--- a/docs/docs/percent-property-input.md
+++ b/docs/docs/percent-property-input.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 4
+---
+
+# Percent Property Input
+
+Represents a fractional value as a percentage.

--- a/docs/docs/property-input.md
+++ b/docs/docs/property-input.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 2
+---
+
+# Property Input
+
+`<cc-property-input>` synchronizes the values of one or more child `<cc-draggable-number>` elements.

--- a/docs/docs/rotation-property-input.md
+++ b/docs/docs/rotation-property-input.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 3
+---
+
+# Rotation Property Input
+
+Displays an angle in rotations and partial degrees using two nested `<cc-draggable-number>` elements.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "build": "npm run typecheck && vite build && vite build --config vite.define.config.ts",
         "lint": "npm run typecheck && eslint --ext .ts src",
         "test": "npm run typecheck && vitest run",
+        "test:e2e": "playwright test",
         "docs:manifest": "cem analyze --litelement --globs \"src/**/*.ts\" --outdir .",
         "docs:api": "typedoc --out docs/api src/index.ts",
         "docs:storybook": "storybook build --docs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './tests/e2e',
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,5 @@
+# Integration Tests
+
+This directory will contain Playwright-based browser tests.
+
+Currently these tests are placeholders.

--- a/tests/e2e/basic.e2e.ts
+++ b/tests/e2e/basic.e2e.ts
@@ -1,0 +1,1 @@
+// Placeholder for future Playwright tests


### PR DESCRIPTION
## Summary
- add minimal doc pages for components
- create placeholder Playwright test setup
- expose `test:e2e` npm script

## Testing
- `npm run lint`
- `npm test`