### PR TITLE
Configure dependabot for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: master
+  - package-ecosystem: npm
+    directory: "/docs"
+    schedule:
+      interval: weekly
+    target-branch: master


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` to handle npm updates for the root and docs packages

## Testing
- `npm run lint`
- `npm test`
